### PR TITLE
Wait for service resource to be ready after creation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
+	github.com/hashicorp/terraform-plugin-framework-timeouts v0.3.0
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.8.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/hashicorp/terraform-plugin-docs v0.13.0 h1:6e+VIWsVGb6jYJewfzq2ok2smP
 github.com/hashicorp/terraform-plugin-docs v0.13.0/go.mod h1:W0oCmHAjIlTHBbvtppWHe8fLfZ2BznQbuv8+UD8OucQ=
 github.com/hashicorp/terraform-plugin-framework v1.1.1 h1:PbnEKHsIU8KTTzoztHQGgjZUWx7Kk8uGtpGMMc1p+oI=
 github.com/hashicorp/terraform-plugin-framework v1.1.1/go.mod h1:DyZPxQA+4OKK5ELxFIIcqggcszqdWWUpTLPHAhS/tkY=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.3.0 h1:+JyyLOcqpnq3aELxmWWxMH5g55ml8NsyLWmYkcSR2fk=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.3.0/go.mod h1:ZvvDe5yPEf3lAv9IP6cqwobqFeXsPMJtPXMX3ZYxahQ=
 github.com/hashicorp/terraform-plugin-go v0.14.3 h1:nlnJ1GXKdMwsC8g1Nh05tK2wsC3+3BL/DBBxFEki+j0=
 github.com/hashicorp/terraform-plugin-go v0.14.3/go.mod h1:7ees7DMZ263q8wQ6E4RdIdR6nHHJtrdt4ogX5lPkX1A=
 github.com/hashicorp/terraform-plugin-log v0.8.0 h1:pX2VQ/TGKu+UU1rCay0OlzosNKe4Nz1pepLXj95oyy0=

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -14,6 +14,7 @@ type Service struct {
 	ID                       string `json:"id"`
 	Name                     string `json:"name"`
 	EnableStorageAutoscaling bool   `json:"enable_storage_autoscaling"`
+	Status                   string `json:"status"`
 }
 
 type CreateServiceRequest struct {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -35,6 +35,15 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 	"timescale": providerserver.NewProtocol6WithError(New("test")()),
 }
 
+type Config struct {
+	Name     string
+	Timeouts Timeouts
+}
+
+type Timeouts struct {
+	Create string
+}
+
 func testAccPreCheck(t *testing.T) {
 	_, ok := os.LookupEnv("TF_VAR_ts_access_token")
 	if !ok {


### PR DESCRIPTION
A helper function from the previous Terraform sdk is used to wait for the service to be ready to accept connections before exiting.