### PR TITLE
Add connection info

### DIFF
--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -46,10 +46,13 @@ type CreateServiceRequest struct {
 	MemoryGB                 string
 }
 
+type CreateServiceResponseData struct {
+	CreateServiceResponse CreateServiceResponse `json:"createService"`
+}
+
 type CreateServiceResponse struct {
-	CreateService struct {
-		Service Service `json:"service"`
-	} `json:"createService"`
+	Service         Service `json:"service"`
+	InitialPassword string  `json:"initialPassword"`
 }
 
 type GetServiceResponse struct {
@@ -60,7 +63,7 @@ type DeleteServiceResponse struct {
 	Service Service `json:"deleteService"`
 }
 
-func (c *Client) CreateService(ctx context.Context, request CreateServiceRequest) (*Service, error) {
+func (c *Client) CreateService(ctx context.Context, request CreateServiceRequest) (*CreateServiceResponse, error) {
 	tflog.Trace(ctx, "Client.CreateService")
 	if request.Name == "" {
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -83,7 +86,7 @@ func (c *Client) CreateService(ctx context.Context, request CreateServiceRequest
 			},
 		},
 	}
-	var resp Response[CreateServiceResponse]
+	var resp Response[CreateServiceResponseData]
 	if err := c.do(ctx, req, &resp); err != nil {
 		return nil, err
 	}
@@ -93,7 +96,7 @@ func (c *Client) CreateService(ctx context.Context, request CreateServiceRequest
 	if resp.Data == nil {
 		return nil, errors.New("no response found")
 	}
-	return &resp.Data.CreateService.Service, nil
+	return &resp.Data.CreateServiceResponse, nil
 }
 
 func (c *Client) GetService(ctx context.Context, id string) (*Service, error) {

--- a/internal/provider/service_resource_test.go
+++ b/internal/provider/service_resource_test.go
@@ -24,6 +24,10 @@ func TestServiceResource_Default_Success(t *testing.T) {
 					resource.TestCheckResourceAttr("timescale_service.resource", "name", "service resource test init"),
 					// Verify ID value is set in state.
 					resource.TestCheckResourceAttrSet("timescale_service.resource", "id"),
+					resource.TestCheckResourceAttrSet("timescale_service.resource", "password"),
+					resource.TestCheckResourceAttrSet("timescale_service.resource", "hostname"),
+					resource.TestCheckResourceAttrSet("timescale_service.resource", "username"),
+					resource.TestCheckResourceAttrSet("timescale_service.resource", "port"),
 				),
 			},
 			// Update service name failing


### PR DESCRIPTION
The service password is provided once during service creation. We save this information along with the host, port, and  to Terraform state to allow connecting to the created service. If the service is refreshed or updated, we write the value from the existing state so the value is not lost.
- closes https://github.com/timescale/terraform-provider-timescale/issues/25