### PR TITLE
Replace ramGB in products with memoryGB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.3.1
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.8.0
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/hashicorp/terraform-plugin-testing v1.1.0
 )
 
@@ -38,6 +37,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.17.3 // indirect
 	github.com/hashicorp/terraform-json v0.15.0 // indirect
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.1.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -26,11 +26,11 @@ var (
 )
 
 type Client struct {
-	httpClient *http.Client
-	apiToken   string
-	projectID  string
-	url        string
-	version    string
+	httpClient       *http.Client
+	apiToken         string
+	projectID        string
+	url              string
+	version          string
 	terraformVersion string
 }
 
@@ -51,12 +51,12 @@ func NewClient(apiToken, projectID, env, terraformVersion string) *Client {
 	url := getURL(env)
 
 	return &Client{
-		httpClient: c,
-		apiToken:   apiToken,
-		projectID:  projectID,
-		url:        url,
-		version: 	env,
-		terraformVersion:terraformVersion,
+		httpClient:       c,
+		apiToken:         apiToken,
+		projectID:        projectID,
+		url:              url,
+		version:          env,
+		terraformVersion: terraformVersion,
 	}
 }
 
@@ -92,8 +92,8 @@ func (c *Client) do(ctx context.Context, req map[string]interface{}, resp interf
 
 	userAgent := request.UserAgent()
 	// add provider and client terraform version
-	userAgent = userAgent + " terraform-provider-timescale/"+c.version 
-	userAgent = userAgent + " terraform/"+c.terraformVersion 
+	userAgent = userAgent + " terraform-provider-timescale/" + c.version
+	userAgent = userAgent + " terraform/" + c.terraformVersion
 	request.Header.Set("User-Agent", userAgent)
 	response, err := c.httpClient.Do(request)
 	if err != nil {

--- a/internal/client/products.go
+++ b/internal/client/products.go
@@ -20,7 +20,7 @@ type Plan struct {
 	RegionCode string  `json:"regionCode"`
 	Price      float64 `json:"price"`
 	MilliCPU   int64   `json:"milliCPU"`
-	RamGB      int64   `json:"ramGB"`
+	MemoryGB   int64   `json:"memoryGB"`
 	StorageGB  int64   `json:"storageGB"`
 }
 

--- a/internal/client/queries/products.graphql
+++ b/internal/client/queries/products.graphql
@@ -8,7 +8,7 @@ query GetProducts {
             productId
             price
             milliCPU
-            ramGB
+            memoryGB
             storageGB
             regionCode
         }

--- a/internal/provider/products_data_source.go
+++ b/internal/provider/products_data_source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	tsClient "github.com/timescale/terraform-provider-timescale/internal/client"
 )
 
@@ -46,7 +47,7 @@ type planModel struct {
 	ProductID  types.String  `tfsdk:"product_id"`
 	Price      types.Float64 `tfsdk:"price"`
 	MilliCPU   types.Int64   `tfsdk:"milli_cpu"`
-	RamGB      types.Int64   `tfsdk:"ram_gb"`
+	MemoryGB   types.Int64   `tfsdk:"memory_gb"`
 	StorageGB  types.Int64   `tfsdk:"storage_gb"`
 	RegionCode types.String  `tfsdk:"region_code"`
 }
@@ -88,7 +89,7 @@ func (d *productsDataSource) Read(ctx context.Context, req datasource.ReadReques
 				RegionCode: types.StringValue(plan.RegionCode),
 				Price:      types.Float64Value(plan.Price),
 				MilliCPU:   types.Int64Value(plan.MilliCPU),
-				RamGB:      types.Int64Value(plan.RamGB),
+				MemoryGB:   types.Int64Value(plan.MemoryGB),
 				StorageGB:  types.Int64Value(plan.StorageGB),
 			})
 		}
@@ -152,7 +153,7 @@ func (d *productsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 									"milli_cpu": schema.Int64Attribute{
 										Computed: true,
 									},
-									"ram_gb": schema.Int64Attribute{
+									"memory_gb": schema.Int64Attribute{
 										Computed: true,
 									},
 									"storage_gb": schema.Int64Attribute{


### PR DESCRIPTION
RamGB was removed from the Graphql schema and replaced with memoryGB.