### PR TITLE
Parallelize tests

### DIFF
--- a/internal/provider/service_data_source_test.go
+++ b/internal/provider/service_data_source_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestServiceDataSource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Read testing

--- a/internal/provider/service_resource_test.go
+++ b/internal/provider/service_resource_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestServiceResource_Default_Success(t *testing.T) {
 	// Test resource creation succeeds and update is not allowed
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
@@ -81,7 +81,7 @@ func TestServiceResource_Timeout(t *testing.T) {
 
 func TestServiceResource_CustomConf(t *testing.T) {
 	// Test resource creation succeeds and update is not allowed
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{


### PR DESCRIPTION
I noticed the CI was running each test one at a time. Since each test creates its own resource, it'll speed up the tests if they run in parallel. As far as I can tell each test runs in its own directory so the state files shouldn't conflict with one another.

This may need to be revisited if we ever get near the service limit for a project.
