### PR TITLE
Update the README with a quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,92 @@
-# Terraform Provider Scaffolding (Terraform Plugin Framework)
-
-_This template repository is built on the [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework). The template repository built on the [Terraform Plugin SDK](https://github.com/hashicorp/terraform-plugin-sdk) can be found at [terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding). See [Which SDK Should I Use?](https://www.terraform.io/docs/plugin/which-sdk.html) in the Terraform documentation for additional information._
-
-This repository is a *template* for a [Terraform](https://www.terraform.io) provider. It is intended as a starting point for creating Terraform providers, containing:
-
-- A resource and a data source (`internal/provider/`),
-- Examples (`examples/`) and generated documentation (`docs/`),
-- Miscellaneous meta files.
-
-These files contain boilerplate code that you will need to edit to create your own Terraform provider. Tutorials for creating Terraform providers can be found on the [HashiCorp Learn](https://learn.hashicorp.com/collections/terraform/providers-plugin-framework) platform. _Terraform Plugin Framework specific guides are titled accordingly._
-
-Please see the [GitHub template repository documentation](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template) for how to create a new repository from this template on GitHub.
-
-Once you've written your provider, you'll want to [publish it on the Terraform Registry](https://www.terraform.io/docs/registry/providers/publishing.html) so that others can use it.
+# Timescale Cloud Terraform Provider
+The Terraform provider for [Timescale Cloud](https://www.timescale.com/cloud).
 
 ## Requirements
-
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.18
 
-## Building The Provider
+## Quick Start
 
+### Authorization
+When you log in to your [Timescale Cloud Account](https://console.cloud.timescale.com/), navigate to the `Project settings` page. 
+From here, you can create client credentials for programmatic usage. Click the `Create credentials` button to generate a new public/secret key pair.
+
+### Project ID
+The project ID can be found from the `Services` dashboard. In the upper right-hand side of the page, click on the three vertical dots to view the project ID. 
+
+Create a `main.tf` configuration file with the following content.
+```hcl
+terraform {
+  required_providers {
+    timescale = {
+      source  = "registry.terraform.io/providers/timescale"
+      version = "x.y.z"
+    }
+  }
+}
+
+provider "timescale" {
+  project_id = var.ts_project_id
+  access_key = var.ts_access_key
+  secret_key = var.ts_secret_key
+}
+
+variable "ts_project_id" {
+  type = string
+}
+
+variable "ts_access_key" {
+  type = string
+}
+
+variable "ts_secret_key" {
+  type = string
+}
+
+resource "timescale_service" "test" {
+  # name       = ""
+  # milli_cpu  = 500
+  # memory_gb  = 2
+  # storage_gb = 10
+}
+```
+
+
+## Local Provider Usage and Development
+#### Requirements
+- [Go](https://go.dev) >= v1.18
+
+#### Building The Provider
 1. Clone the repository
 1. Enter the repository directory
 1. Build the provider using the Go `install` command:
 
 ```shell
-go install
+go install .
 ```
 
-## Adding Dependencies
+### Local provider development override
+To use the locally built provider, create a `~/.terraformrc` file with the following content
 
-This provider uses [Go modules](https://github.com/golang/go/wiki/Modules).
-Please see the Go documentation for the most up to date information about using Go modules.
+```text
+provider_installation {
 
-To add a new dependency `github.com/author/dependency` to your Terraform provider:
+dev_overrides {
+   "registry.terraform.io/providers/timescale" = "<PATH>"
+}
 
-```shell
-go get github.com/author/dependency
-go mod tidy
+direct {}
+}
 ```
+Change the `<Path>` variable to be the location of your `GOBIN`.
 
-Then commit the changes to `go.mod` and `go.sum`.
-
-## Using the provider
-
-Fill this in for each provider
-
-## Developing the Provider
-
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).
-
+### Developing the Provider
 To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 To generate or update documentation, run `go generate`.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
+*Note:* Acceptance tests create real resources.
 
 ```shell
 make testacc

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -50,13 +50,11 @@ func (p *TimescaleProvider) Schema(ctx context.Context, req provider.SchemaReque
 		MarkdownDescription: "The Terraform provider for [Timescale Cloud](https://console.cloud.timescale.com/).",
 		Attributes: map[string]schema.Attribute{
 			"access_token": schema.StringAttribute{
-				// TODO: Document once client credentials is available
 				MarkdownDescription: "Access Token",
 				Optional:            true,
 				Sensitive:           true,
 			},
 			"project_id": schema.StringAttribute{
-				// TODO: Document how a user should find their project id
 				MarkdownDescription: "Project ID",
 				Optional:            true,
 			},


### PR DESCRIPTION
Replace the template README with one that provides instructions for how to use the Timescale provider.
