### PR TITLE
Handle timeouts when waiting for a service to be ready

### DIFF
--- a/internal/provider/service_resource_test.go
+++ b/internal/provider/service_resource_test.go
@@ -61,6 +61,24 @@ func TestServiceResource_Default_Success(t *testing.T) {
 	})
 }
 
+func TestServiceResource_Timeout(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: newServiceConfig(Config{
+					Name: "service resource test timeout",
+					Timeouts: Timeouts{
+						Create: "1s",
+					},
+				}),
+				ExpectError: regexp.MustCompile(ErrCreateTimeout),
+			},
+		},
+	})
+}
+
 func TestServiceResource_CustomConf(t *testing.T) {
 	// Test resource creation succeeds and update is not allowed
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
If a timeout occurs waiting for a service to available, the provider attempts to delete the service to prevent having resources running for a project that Terraform is unaware of.