### PR TITLE
Some token improvements

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -66,16 +66,10 @@ func NewClient(token, projectID, env, terraformVersion string) *Client {
 }
 
 func getURL(env string) string {
-	url := "https://console.cloud.timescale.com/api/query"
-	if env != "test" {
-		return url
+	if value, ok := os.LookupEnv("TIMESCALE_DEV_URL"); ok {
+		return value
 	}
-	// This environment variable is used to configure the client for testing.
-	value, ok := os.LookupEnv("TIMESCALE_DEV_URL")
-	if !ok {
-		return url
-	}
-	return value
+	return "https://console.cloud.timescale.com/api/query"
 }
 
 type JWTFromCCResponse struct {


### PR DESCRIPTION
This fixes a crash with invalid CCs.
Also enables to run it on dev like this: `go build && TIMESCALE_DEV_URL="https://api.dev.metronome-cloud.com/api/query" terraform apply --auto-approve`
Not sure why we require "test" version to support this.