### PR TITLE
Update Go version to 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ resource "timescale_service" "test" {
 
 ## Local Provider Usage and Development
 #### Requirements
-- [Go](https://go.dev) >= v1.18
+- [Go](https://go.dev) >= v1.20
 
 #### Building The Provider
 1. Clone the repository

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/timescale/terraform-provider-timescale
 
-go 1.18
+go 1.20
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.14.1


### PR DESCRIPTION
The latest dependabot change requires running at least Go ~1.19~ 1.20