### PR TITLE
Fix name getting set to empty on updates

### DIFF
--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -101,6 +101,9 @@ The change has been taken into account but must still be propagated. You can run
 				Optional:            true,
 				// If the name attribute is absent, the provider will generate a default.
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"milli_cpu": schema.Int64Attribute{
 				MarkdownDescription: "Milli CPU",

--- a/internal/provider/service_resource_test.go
+++ b/internal/provider/service_resource_test.go
@@ -154,7 +154,7 @@ func TestServiceResource_CustomConf(t *testing.T) {
 			},
 			// Create with HA and VPC attached
 			{
-				Config: newServiceCustomVpcConfig("hareplica", Config{
+				Config: newServiceCustomVpcConfig("hareplica_vpc", Config{
 					Name:            "service resource test HA",
 					RegionCode:      "us-east-1",
 					MilliCPU:        500,
@@ -163,9 +163,9 @@ func TestServiceResource_CustomConf(t *testing.T) {
 					VpcID:           DEFAULT_VPC_ID,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("timescale_service.hareplica", "name", "service resource test HA"),
-					resource.TestCheckResourceAttr("timescale_service.hareplica", "enable_ha_replica", "true"),
-					resource.TestCheckResourceAttr("timescale_service.hareplica", "vpc_id", "2074"),
+					resource.TestCheckResourceAttr("timescale_service.hareplica_vpc", "name", "service resource test HA"),
+					resource.TestCheckResourceAttr("timescale_service.hareplica_vpc", "enable_ha_replica", "true"),
+					resource.TestCheckResourceAttr("timescale_service.hareplica_vpc", "vpc_id", "2074"),
 				),
 			},
 		},


### PR DESCRIPTION
The name field was getting set to empty on changes to HA replicas. This fixes it the issue by using the previous known state for the name field on updates