### PR TITLE
Fix name getting set to empty on updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/hashicorp/terraform-plugin-testing v1.2.0
+	github.com/stretchr/testify v1.7.2
 )
 
 require (
@@ -23,6 +24,7 @@ require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
@@ -55,6 +57,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
@@ -72,4 +75,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	google.golang.org/grpc v1.59.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -101,6 +101,9 @@ The change has been taken into account but must still be propagated. You can run
 				Optional:            true,
 				// If the name attribute is absent, the provider will generate a default.
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"milli_cpu": schema.Int64Attribute{
 				MarkdownDescription: "Milli CPU",


### PR DESCRIPTION
The name field was getting set to empty on changes to ha replicas. This fixes the issue by using the previous known state for the name field on updates.

To test this, the test is reordered so the spec gets updated first. Previously this step would fail because the service name would be set to empty instead of the generated value in the first step. 

The tests are refactored so a config can create a terraform configuration based on the values that are set. This makes the tests more stable by providing better control over what fields change between test steps. Before, there were multiple methods to set different combinations of fields which makes it difficult to understand whats changing.