### PR TITLE
Expectation management

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 # Timescale Terraform Provider
-The Terraform provider for [Timescale](https://www.timescale.com/cloud).
+The Terraform provider for [Timescale Cloud](https://www.timescale.com/cloud).
 
 ## Requirements
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.0
@@ -7,7 +7,7 @@ The Terraform provider for [Timescale](https://www.timescale.com/cloud).
 ## Quick Start
 
 ### Authorization
-When you log in to your [Timescale Account](https://console.cloud.timescale.com/), navigate to the `Project settings` page.
+When you log in to your [Timescale Cloud Account](https://console.cloud.timescale.com/), navigate to the `Project settings` page.
 From here, you can create client credentials for programmatic usage. Click the `Create credentials` button to generate a new public/secret key pair.
 
 ### Project ID


### PR DESCRIPTION
Provider is not intended for use with Managed Timescale, see https://github.com/timescale/terraform-provider-timescale/issues/84#issuecomment-1988002668

This change makes it explicit and leaves no doubt. I was in doubt about adding a section to explicitly state that this provider is not meant for Managed Timescale. Should this be done?