### PR TITLE
add devenv to simplify local dev and ci

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-d+8cBpDfDBj41inrADaJt+bDWhOktwslgoP5YiGJ1v0="
+
+use devenv

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: devenv shell run_ci_lint
+      - run: devenv shell -- pre-commit run golangci-lint --all-files

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,8 @@ jobs:
       - uses: cachix/install-nix-action@v26
       - uses: cachix/cachix-action@v14
         with:
-          name: devenv
+          name: terraform-provider-timescale
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
       - run: devenv shell -- pre-commit run golangci-lint --all-files

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,4 @@
-name: golangci-lint
+name: lint
 on:
   push:
     tags:
@@ -9,38 +9,16 @@ on:
   pull_request:
 permissions:
   contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
 jobs:
   golangci:
-    name: lint
+    name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.21'
       - uses: actions/checkout@v4
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v5
+      - uses: cachix/install-nix-action@v26
+      - uses: cachix/cachix-action@v14
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.54.2
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the all caching functionality will be complete disabled,
-          #           takes precedence over all other caching options.
-          # skip-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
+          name: devenv
+      - name: Install devenv.sh
+        run: nix profile install nixpkgs#devenv
+      - run: devenv shell run_ci_lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,10 @@ jobs:
       - uses: cachix/install-nix-action@v26
       - uses: cachix/cachix-action@v14
         with:
-          name: devenv
+          name: terraform-provider-timescale
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Install devenv.sh
+        run: nix profile install nixpkgs#devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
       - run: devenv build
@@ -30,7 +33,8 @@ jobs:
       - uses: cachix/install-nix-action@v26
       - uses: cachix/cachix-action@v14
         with:
-          name: devenv
+          name: terraform-provider-timescale
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
       - run: devenv shell run-mod-download
@@ -45,7 +49,8 @@ jobs:
       - uses: cachix/install-nix-action@v26
       - uses: cachix/cachix-action@v14
         with:
-          name: devenv
+          name: terraform-provider-timescale
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
       - run: devenv shell run-mod-download

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - name: Install devenv.sh
-        run: nix profile install nixpkgs#devenv
       - run: devenv build
   generate:
     name: Generate
@@ -37,8 +35,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: devenv shell run-mod-download
-      - run: devenv shell run-generate
+      - run: devenv tasks run dev:gen
       - run: devenv shell -- pre-commit run generate-check
   test:
     name: Acceptance Tests
@@ -53,7 +50,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: devenv shell run-mod-download
+      - run: devenv tasks run dev:mod
       - env:
           TF_ACC: "1"
           TF_VAR_ts_access_key: ${{ secrets.TF_VAR_TS_ACCESS_KEY }}
@@ -63,4 +60,4 @@ jobs:
           # point to API
           TIMESCALE_DEV_URL: ${{ secrets.TIMESCALE_DEV_URL }}
         run: devenv test
-        timeout-minutes: 10
+        timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,12 @@
 # Terraform Provider testing workflow.
-name: Tests
-
-# This GitHub action runs your tests for each pull request and push.
-# Optionally, you can turn it on using a schedule for regular testing.
+name: integration-tests
 on:
   push:
     paths-ignore:
-      - 'README.md'
-
+      - "README.md"
 # Testing only needs permissions to read the repository contents.
 permissions:
   contents: read
-
 jobs:
   # Ensure project builds before running testing matrix
   build:
@@ -20,51 +15,41 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4 # v3.3.0
-      - uses: actions/setup-go@v5 # v4.0.0
+      - uses: cachix/install-nix-action@v26
+      - uses: cachix/cachix-action@v14
         with:
-          go-version-file: 'go.mod'
-          cache: true
-      - run: go mod download
-      - run: go build -v .
-
+          name: devenv
+      - name: Install devenv.sh
+        run: nix profile install nixpkgs#devenv
+      - run: devenv shell run_mod_download
+      - run: devenv shell run_build
   generate:
+    name: Generate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4 # v3.3.0
-      - uses: actions/setup-go@v5 # v4.0.0
+      - uses: cachix/install-nix-action@v26
+      - uses: cachix/cachix-action@v14
         with:
-          go-version-file: 'go.mod'
-          cache: true
-      - run: go generate ./...
-      - name: git diff
-        run: |
-          git diff --compact-summary --exit-code || \
-            (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
-
-  # Run acceptance tests in a matrix with Terraform CLI versions
+          name: devenv
+      - name: Install devenv.sh
+        run: nix profile install nixpkgs#devenv
+      - run: devenv shell run_mod_download
+      - run: devenv shell run_generate
+      - run: devenv shell run_diff
   test:
-    name: Terraform Provider Acceptance Tests
-    needs: build
+    name: Acceptance Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          # - '1.0.*'
-          # - '1.1.*'
-          - '1.2.*'
     steps:
-      - uses: actions/checkout@v4 # v3.3.0
-      - uses: actions/setup-go@v5 # v4.0.0
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v26
+      - uses: cachix/cachix-action@v14
         with:
-          go-version-file: 'go.mod'
-          cache: true
-      - uses: hashicorp/setup-terraform@97f030cf6dc0b4f5e0da352c7bca9cca34579800 # v3.1.0
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
+          name: devenv
+      - name: Install devenv.sh
+        run: nix profile install nixpkgs#devenv
+
       - run: go mod download
       - env:
           TF_ACC: "1"
@@ -74,5 +59,5 @@ jobs:
           TF_VAR_ts_aws_acc_id: ${{ secrets.TF_VAR_TS_AWS_ACC_ID }}
           # point to API
           TIMESCALE_DEV_URL: ${{ secrets.TIMESCALE_DEV_URL }}
-        run: go test -v -cover ./internal/provider/
+        run: devenv test
         timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,7 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: devenv shell run-mod-download
-      - run: devenv shell -- go build -v .
+      - run: devenv build
   generate:
     name: Generate
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: devenv shell run_mod_download
-      - run: devenv shell run_build
+      - run: devenv shell run-mod-download
+      - run: devenv shell -- go build -v .
   generate:
     name: Generate
     runs-on: ubuntu-latest
@@ -34,9 +34,9 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: devenv shell run_mod_download
-      - run: devenv shell run_generate
-      - run: devenv shell run_diff
+      - run: devenv shell run-mod-download
+      - run: devenv shell run-generate
+      - run: devenv shell -- pre-commit run generate-check
   test:
     name: Acceptance Tests
     runs-on: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: devenv shell run_mod_download
+      - run: devenv shell run-mod-download
       - env:
           TF_ACC: "1"
           TF_VAR_ts_access_key: ${{ secrets.TF_VAR_TS_ACCESS_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,7 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-
-      - run: go mod download
+      - run: devenv shell run_mod_download
       - env:
           TF_ACC: "1"
           TF_VAR_ts_access_key: ${{ secrets.TF_VAR_TS_ACCESS_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ website/vendor
 
 # Keep windows files with windows line endings
 *.winfile eol=crlf
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,7 @@
+{ pkgs, name, version, ... }:
+pkgs.buildGoModule {
+  pname = name;
+  version = version;
+  src = ./.;
+  vendorHash = "sha256-ZDVMtvb49psIN+F4tABKl03HUvx/h6aOPs0Oni+KqqQ=";
+}

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,12 @@
 { pkgs, name, version, ... }:
-pkgs.buildGoModule {
+pkgs.buildGoApplication {
   pname = name;
   version = version;
-  src = ./.;
-  vendorHash = "sha256-ZDVMtvb49psIN+F4tABKl03HUvx/h6aOPs0Oni+KqqQ=";
+
+  src = builtins.path {
+    path = ./.;
+    name = "source";
+  };
+
+  modules = ./gomod2nix.toml;
 }

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,122 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1725907707,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "2bbbbc468fc02257265a79652a8350651cca495a",
+        "treeHash": "d9591aad1e4921ef1af48692918d128d37306d54",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716977621,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
+        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1725826545,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f4c846aee8e1e29062aa8514d5e0ab270f4ec2f9",
+        "treeHash": "8fc49deaed3f2728a7147c38163cc468a117570a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1725513492,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "treeHash": "4b46d77870afecd8f642541cb4f4927326343b59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1725964132,
+        "lastModified": 1726063457,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "98c7c131e3fa30eb00e9bfe44c1a180c7f94102f",
-        "treeHash": "145543926bdaaeabf22cd0f42e2991d0e35131c4",
+        "rev": "39bf6ce569103c9390d37322daa59468c31b3ce7",
         "type": "github"
       },
       "original": {
@@ -24,7 +23,6 @@
         "owner": "edolstra",
         "repo": "flake-compat",
         "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
         "type": "github"
       },
       "original": {
@@ -45,7 +43,6 @@
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
         "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
         "type": "github"
       },
       "original": {
@@ -60,7 +57,6 @@
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
         "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
-        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
         "type": "github"
       },
       "original": {
@@ -72,11 +68,10 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725826545,
+        "lastModified": 1725930920,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4c846aee8e1e29062aa8514d5e0ab270f4ec2f9",
-        "treeHash": "8fc49deaed3f2728a7147c38163cc468a117570a",
+        "rev": "44a71ff39c182edaf25a7ace5c9454e7cba2c658",
         "type": "github"
       },
       "original": {
@@ -100,7 +95,6 @@
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
         "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
-        "treeHash": "4b46d77870afecd8f642541cb4f4927326343b59",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1725907707,
+        "lastModified": 1725964132,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "2bbbbc468fc02257265a79652a8350651cca495a",
-        "treeHash": "d9591aad1e4921ef1af48692918d128d37306d54",
+        "rev": "98c7c131e3fa30eb00e9bfe44c1a180c7f94102f",
+        "treeHash": "145543926bdaaeabf22cd0f42e2991d0e35131c4",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1729179079,
+        "lastModified": 1729445229,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "11c71a53661aff81b0f93d2958500d8c9ab71866",
+        "rev": "006016cf4191c34c17cfdb6669e0690e24302ac0",
         "type": "github"
       },
       "original": {
@@ -74,10 +74,10 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1728509152,
+        "lastModified": 1729448365,
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "d5547e530464c562324f171006fc8f639aa01c9f",
+        "rev": "5d387097aa716f35dd99d848dc26d8d5b62a104c",
         "type": "github"
       },
       "original": {
@@ -88,10 +88,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729186406,
+        "lastModified": 1729518194,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73bd40281687e5bd0dadb63b34865231fd20e7e4",
+        "rev": "85c9ca36ebc475d17309acdcb0608b0ca33f8a0f",
         "type": "github"
       },
       "original": {
@@ -103,10 +103,10 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1728909085,
+        "lastModified": 1729307008,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0b1da36f7c34a7146501f684e9ebdf15d2bebf8",
+        "rev": "a9b86fc2290b69375c5542b622088eb6eca2a7c3",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1726063457,
+        "lastModified": 1729179079,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "39bf6ce569103c9390d37322daa59468c31b3ce7",
+        "rev": "11c71a53661aff81b0f93d2958500d8c9ab71866",
         "type": "github"
       },
       "original": {
@@ -36,10 +36,10 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
+        "lastModified": 1726560853,
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -74,10 +74,10 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1725515722,
+        "lastModified": 1728509152,
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "1c6fd4e862bf2f249c9114ad625c64c6c29a8a08",
+        "rev": "d5547e530464c562324f171006fc8f639aa01c9f",
         "type": "github"
       },
       "original": {
@@ -88,10 +88,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726073643,
+        "lastModified": 1729186406,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "758fd9dd53af731d11b23977fd1fdcc86b97b5c7",
+        "rev": "73bd40281687e5bd0dadb63b34865231fd20e7e4",
         "type": "github"
       },
       "original": {
@@ -103,10 +103,10 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725930920,
+        "lastModified": 1728909085,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44a71ff39c182edaf25a7ace5c9454e7cba2c658",
+        "rev": "c0b1da36f7c34a7146501f684e9ebdf15d2bebf8",
         "type": "github"
       },
       "original": {
@@ -141,10 +141,10 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725513492,
+        "lastModified": 1729104314,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -31,6 +31,23 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -51,18 +68,36 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "gomod": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1716977621,
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
+        "lastModified": 1725515722,
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "1c6fd4e862bf2f249c9114ad625c64c6c29a8a08",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726073643,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "758fd9dd53af731d11b23977fd1fdcc86b97b5c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -78,6 +113,21 @@
         "owner": "NixOS",
         "ref": "nixos-24.05",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1716977621,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
         "type": "github"
       }
     },
@@ -106,8 +156,23 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "nixpkgs": "nixpkgs",
+        "gomod": "gomod",
+        "nixpkgs": "nixpkgs_2",
         "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,5 +1,5 @@
 { pkgs, lib, config, inputs, ... }: {
-  packages = [ pkgs.git ];
+  packages = [ pkgs.git pkgs.gomod2nix ];
 
   languages = {
     go.enable = true;
@@ -29,7 +29,7 @@
   outputs = let
     name = "terraform-provider-timescale";
     version = "1.11.0";
-    app = import ./app.nix { inherit pkgs name version; };
+    app = import ./default.nix { inherit pkgs name version; };
   in {
     app = app;
     image = import ./image.nix { inherit pkgs app name version; };
@@ -38,6 +38,7 @@
   scripts = {
     run-mod-download.exec = ''
       go mod download
+      gomod2nix
     '';
     run-generate.exec = ''
       go generate ./...

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,5 +1,13 @@
-{ pkgs, lib, config, inputs, ... }: {
-  packages = with pkgs; [ git terraform golangci-lint ];
+{ pkgs, lib, config, inputs, ... }:
+let
+  providerBin = pkgs.buildGoModule {
+    pname = "terraform-provider-timescale";
+    version = "1.11.0";
+    src = ./.;
+    vendorHash = "sha256-ZDVMtvb49psIN+F4tABKl03HUvx/h6aOPs0Oni+KqqQ=";
+  };
+in {
+  packages = with pkgs; [ git terraform golangci-lint providerBin ];
 
   languages.go.enable = true;
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -7,11 +7,11 @@ let
     vendorHash = "sha256-ZDVMtvb49psIN+F4tABKl03HUvx/h6aOPs0Oni+KqqQ=";
   };
 in {
-  packages = with pkgs; [ git terraform ];
+  packages = [ pkgs.git ];
 
   languages.go.enable = true;
+  languages.terraform.enable = true;
 
-  pre-commit.src = ./.;
   pre-commit.hooks = {
     govet = {
       enable = true;

--- a/devenv.nix
+++ b/devenv.nix
@@ -9,8 +9,10 @@ let
 in {
   packages = [ pkgs.git ];
 
-  languages.go.enable = true;
-  languages.terraform.enable = true;
+  languages = {
+    go.enable = true;
+    terraform.enable = true;
+  };
 
   pre-commit.hooks = {
     govet = {

--- a/devenv.nix
+++ b/devenv.nix
@@ -7,14 +7,24 @@ let
     vendorHash = "sha256-ZDVMtvb49psIN+F4tABKl03HUvx/h6aOPs0Oni+KqqQ=";
   };
 in {
-  packages = with pkgs; [ git terraform golangci-lint providerBin ];
+  packages = with pkgs; [ git terraform ];
 
   languages.go.enable = true;
 
+  pre-commit.src = ./.;
+  pre-commit.hooks = {
+    govet = {
+      enable = true;
+      pass_filenames = false;
+    };
+    gotest.enable = true;
+    golangci-lint = {
+      enable = true;
+      pass_filenames = false;
+    };
+  };
+
   scripts = {
-    run_ci_lint.exec = ''
-      golangci-lint run
-    '';
     run_mod_download.exec = ''
       go mod download
     '';
@@ -29,8 +39,4 @@ in {
         (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
     '';
   };
-
-  enterTest = ''
-    go test -v -cover ./internal/provider/
-  '';
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,28 @@
+{ pkgs, lib, config, inputs, ... }: {
+  packages = with pkgs; [ git terraform golangci-lint ];
+
+  languages.go.enable = true;
+
+  scripts = {
+    run_ci_lint.exec = ''
+      golangci-lint run
+    '';
+    run_mod_download.exec = ''
+      go mod download
+    '';
+    run_build.exec = ''
+      go build -v .
+    '';
+    run_generate.exec = ''
+      go generate ./...
+    '';
+    run_diff.exec = ''
+      git diff --compact-summary --exit-code || \
+        (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
+    '';
+  };
+
+  enterTest = ''
+    go test -v -cover ./internal/provider/
+  '';
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -22,21 +22,26 @@ in {
       enable = true;
       pass_filenames = false;
     };
+    generate-check = {
+      enable = true;
+      name = "Go generate checks";
+      entry = ''
+        run-diff
+      '';
+      pass_filenames = false;
+    };
   };
 
   scripts = {
-    run_mod_download.exec = ''
+    run-mod-download.exec = ''
       go mod download
     '';
-    run_build.exec = ''
-      go build -v .
-    '';
-    run_generate.exec = ''
+    run-generate.exec = ''
       go generate ./...
     '';
-    run_diff.exec = ''
+    run-diff.exec = ''
       git diff --compact-summary --exit-code || \
-        (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
+        (echo; echo "Unexpected difference in directories after code generation. Run 'run-generate' command and commit."; exit 1)
     '';
   };
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,12 +1,4 @@
-{ pkgs, lib, config, inputs, ... }:
-let
-  providerBin = pkgs.buildGoModule {
-    pname = "terraform-provider-timescale";
-    version = "1.11.0";
-    src = ./.;
-    vendorHash = "sha256-ZDVMtvb49psIN+F4tABKl03HUvx/h6aOPs0Oni+KqqQ=";
-  };
-in {
+{ pkgs, lib, config, inputs, ... }: {
   packages = [ pkgs.git ];
 
   languages = {
@@ -32,6 +24,15 @@ in {
       '';
       pass_filenames = false;
     };
+  };
+
+  outputs = let
+    name = "terraform-provider-timescale";
+    version = "1.11.0";
+    app = import ./app.nix { inherit pkgs name version; };
+  in {
+    app = app;
+    image = import ./image.nix { inherit pkgs app name version; };
   };
 
   scripts = {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+allowUnfree: true

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -2,4 +2,8 @@
 inputs:
   nixpkgs:
     url: github:cachix/devenv-nixpkgs/rolling
+  gomod:
+    url: github:nix-community/gomod2nix
+    overlays:
+      - default
 allowUnfree: true

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,240 @@
+schema = 3
+
+[mod]
+  [mod."github.com/Kunde21/markdownfmt/v3"]
+    version = "v3.1.0"
+    hash = "sha256-wku1uear1V9gPsZ/fUsGe+k2OK/KlwwpFRA9oWJb92k="
+  [mod."github.com/Masterminds/goutils"]
+    version = "v1.1.1"
+    hash = "sha256-MEvA5e099GUllILa5EXxa6toQexU1sz6eDZt2tiqpCY="
+  [mod."github.com/Masterminds/semver/v3"]
+    version = "v3.2.0"
+    hash = "sha256-JaGYNQwDxFCsLwzYVoJY4RUpP4dtiRlV14t2dVAg4oQ="
+  [mod."github.com/Masterminds/sprig/v3"]
+    version = "v3.2.3"
+    hash = "sha256-1GLZic3WQIBZGyjvyHbfcZ/7EV7oNzNhkwEiiTpVfL4="
+  [mod."github.com/ProtonMail/go-crypto"]
+    version = "v1.1.0-alpha.2-proton"
+    hash = "sha256-ITgoUrlQHhesVk6YvHqRrUukjijE74IZnJkf6tMSTzY="
+  [mod."github.com/agext/levenshtein"]
+    version = "v1.2.3"
+    hash = "sha256-d1lUB0kToOsPYfRmEh9SO+iVipgmsRs4xQkj1xlY9og="
+  [mod."github.com/apparentlymart/go-textseg/v15"]
+    version = "v15.0.0"
+    hash = "sha256-960kVVQSGhx1Gww5cfoNeM3yXaA4dwlv+AFhKh6EGlA="
+  [mod."github.com/armon/go-radix"]
+    version = "v1.0.0"
+    hash = "sha256-A5SNdGtw8I6ngk9U3p+rKu6KB7inSngqmdnJl74EM9Q="
+  [mod."github.com/bgentry/speakeasy"]
+    version = "v0.1.0"
+    hash = "sha256-Gt1vj6CFovLnO6wX5u2O4UfecY9V2J9WGw1ez4HMrgk="
+  [mod."github.com/cloudflare/circl"]
+    version = "v1.3.8"
+    hash = "sha256-6FbUbOjD8UDb2DIUzVCtI6S+Ja7Dk1pQLc0j0SWZaCk="
+  [mod."github.com/davecgh/go-spew"]
+    version = "v1.1.1"
+    hash = "sha256-nhzSUrE1fCkN0+RL04N4h8jWmRFPPPWbCuDc7Ss0akI="
+  [mod."github.com/fatih/color"]
+    version = "v1.16.0"
+    hash = "sha256-Aq/SM28aPJVzvapllQ64R/DM4aZ5CHPewcm/AUJPyJQ="
+  [mod."github.com/golang/protobuf"]
+    version = "v1.5.4"
+    hash = "sha256-N3+Lv9lEZjrdOWdQhFj6Y3Iap4rVLEQeI8/eFFyAMZ0="
+  [mod."github.com/google/go-cmp"]
+    version = "v0.6.0"
+    hash = "sha256-qgra5jze4iPGP0JSTVeY5qV5AvEnEu39LYAuUCIkMtg="
+  [mod."github.com/google/uuid"]
+    version = "v1.6.0"
+    hash = "sha256-VWl9sqUzdOuhW0KzQlv0gwwUQClYkmZwSydHG2sALYw="
+  [mod."github.com/hashicorp/cli"]
+    version = "v1.1.6"
+    hash = "sha256-/rcjznXypJYwDLDAQ4G7hFkeugXRNx0XSftGK76Js5E="
+  [mod."github.com/hashicorp/errwrap"]
+    version = "v1.1.0"
+    hash = "sha256-6lwuMQOfBq+McrViN3maJTIeh4f8jbEqvLy2c9FvvFw="
+  [mod."github.com/hashicorp/go-checkpoint"]
+    version = "v0.5.0"
+    hash = "sha256-QZe6mSoWT4M3B8BGlslHr/1eLrYfzvHhhmHQ69m0QLw="
+  [mod."github.com/hashicorp/go-cleanhttp"]
+    version = "v0.5.2"
+    hash = "sha256-N9GOKYo7tK6XQUFhvhImtL7PZW/mr4C4Manx/yPVvcQ="
+  [mod."github.com/hashicorp/go-cty"]
+    version = "v1.4.1-0.20200414143053-d3edf31b6320"
+    hash = "sha256-corGsnYW1m9ktTDMBjfggM2GRZKSeG8dPDAMJ5nzjss="
+  [mod."github.com/hashicorp/go-hclog"]
+    version = "v1.6.3"
+    hash = "sha256-BK2s+SH1tQyUaXCH4kC0/jgqiSu638UFbwamfKjFOYg="
+  [mod."github.com/hashicorp/go-multierror"]
+    version = "v1.1.1"
+    hash = "sha256-ANzPEUJIZIlToxR89Mn7Db73d9LGI51ssy7eNnUgmlA="
+  [mod."github.com/hashicorp/go-plugin"]
+    version = "v1.6.0"
+    hash = "sha256-NeY86Z+qJwt0NPV4cNmWDiTryDPSiyKMkS1ivRX9ThE="
+  [mod."github.com/hashicorp/go-uuid"]
+    version = "v1.0.3"
+    hash = "sha256-8893qBbaug2yhxElowSrl3PrfhYlQ7cZ71QBgZWqpHE="
+  [mod."github.com/hashicorp/go-version"]
+    version = "v1.6.0"
+    hash = "sha256-UV0equpmW6BiJnp4W3TZlSJ+PTHuTA+CdOs2JTeHhjs="
+  [mod."github.com/hashicorp/hc-install"]
+    version = "v0.6.4"
+    hash = "sha256-ksptXXU6vEi9eZrrA0TDvmC6L+gL2XZt511Tsqmix+w="
+  [mod."github.com/hashicorp/hcl/v2"]
+    version = "v2.20.1"
+    hash = "sha256-Uqg+r9sEEWf1af7iig07cRcySEwkswjg9TXN7VrgIh4="
+  [mod."github.com/hashicorp/logutils"]
+    version = "v1.0.0"
+    hash = "sha256-e8t8Dm8sp/PzKClN1TOmFcrTAWNh4mZHSW7cAjVx3Bw="
+  [mod."github.com/hashicorp/terraform-exec"]
+    version = "v0.20.0"
+    hash = "sha256-pZAV6JZiN9NCPFuQI3IgVSmqstAVDlgLYT5rOwo3XqM="
+  [mod."github.com/hashicorp/terraform-json"]
+    version = "v0.21.0"
+    hash = "sha256-u1uqTdFAPk2dQeR1YtBiRLKVcJbzvKW79MVQBpBQK5k="
+  [mod."github.com/hashicorp/terraform-plugin-docs"]
+    version = "v0.17.0"
+    hash = "sha256-+iN1rjLr/nGNSvldkxG80ay9jBpbechPgZ3Hk+MxajY="
+  [mod."github.com/hashicorp/terraform-plugin-framework"]
+    version = "v1.8.0"
+    hash = "sha256-PQ4k2eZw9rdMVSLZTM0ajD9cNI5U5bjYOZ4wsRjmW5g="
+  [mod."github.com/hashicorp/terraform-plugin-framework-timeouts"]
+    version = "v0.4.1"
+    hash = "sha256-PucBfXDGKplDSTEEUwtnNIo3rmsVw0HfXK5lXM/tPZY="
+  [mod."github.com/hashicorp/terraform-plugin-framework-validators"]
+    version = "v0.12.0"
+    hash = "sha256-qKTlQzu6gzuU8Y4L2x8y0A5Yhxv19dixpmjMbA6a8Fc="
+  [mod."github.com/hashicorp/terraform-plugin-go"]
+    version = "v0.22.2"
+    hash = "sha256-t4Fm6+yh/A6hsDprLxg4PzTI6VlEVwo46rMNNzS2aEQ="
+  [mod."github.com/hashicorp/terraform-plugin-log"]
+    version = "v0.9.0"
+    hash = "sha256-YnzFZQIzb+NHKb7qVBXk+7FGelkSVWGp7ij1G1RUIUg="
+  [mod."github.com/hashicorp/terraform-plugin-sdk/v2"]
+    version = "v2.33.0"
+    hash = "sha256-Vv4G1YgP1kA0o+eaDip219Y4ISqerfwcXD/XzcvdGkg="
+  [mod."github.com/hashicorp/terraform-plugin-testing"]
+    version = "v1.7.0"
+    hash = "sha256-tOaiz5IdsFJY87ExfsSRUTdmzCQVobY2xWwP5gapxBE="
+  [mod."github.com/hashicorp/terraform-registry-address"]
+    version = "v0.2.3"
+    hash = "sha256-evVRKhphTvhCvdT1XwcMXbbbKBnaZhdxEU93sot4yp0="
+  [mod."github.com/hashicorp/terraform-svchost"]
+    version = "v0.1.1"
+    hash = "sha256-kY0Dcmr4CXHaSx1keJrEfsgsxYhxh8Abh5kicmlZDGQ="
+  [mod."github.com/hashicorp/yamux"]
+    version = "v0.1.1"
+    hash = "sha256-jr4ZFM3XHSwGoZcRcmmdGTq4IqxBTnimojIPDgK0USU="
+  [mod."github.com/huandu/xstrings"]
+    version = "v1.3.3"
+    hash = "sha256-xtauGYk7SnC2LMnCD+dc5dBhNFNfFnkWXcKyHQNaaK0="
+  [mod."github.com/imdario/mergo"]
+    version = "v0.3.15"
+    hash = "sha256-HyN1PxCZW2IRns9VDkwxMHtDvdDwaRgat0wcHf53B0w="
+  [mod."github.com/mattn/go-colorable"]
+    version = "v0.1.13"
+    hash = "sha256-qb3Qbo0CELGRIzvw7NVM1g/aayaz4Tguppk9MD2/OI8="
+  [mod."github.com/mattn/go-isatty"]
+    version = "v0.0.20"
+    hash = "sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ="
+  [mod."github.com/mattn/go-runewidth"]
+    version = "v0.0.9"
+    hash = "sha256-dK/kIPe1tcxEubwI4CWfov/HWRBgD/fqlPC3d5i30CY="
+  [mod."github.com/mitchellh/copystructure"]
+    version = "v1.2.0"
+    hash = "sha256-VR9cPZvyW62IHXgmMw8ee+hBDThzd2vftgPksQYR/Mc="
+  [mod."github.com/mitchellh/go-testing-interface"]
+    version = "v1.14.1"
+    hash = "sha256-TMGi38D13BEVN5cpeKDzKRIgLclm4ErOG+JEyqJrN/c="
+  [mod."github.com/mitchellh/go-wordwrap"]
+    version = "v1.0.1"
+    hash = "sha256-fiD7kh5037BjA0vW6A2El0XArkK+4S5iTBjJB43BNYo="
+  [mod."github.com/mitchellh/mapstructure"]
+    version = "v1.5.0"
+    hash = "sha256-ztVhGQXs67MF8UadVvG72G3ly0ypQW0IRDdOOkjYwoE="
+  [mod."github.com/mitchellh/reflectwalk"]
+    version = "v1.0.2"
+    hash = "sha256-VX9DPqChm7jPnyrA3RAYgxAFrAhj7TRKIWD/qR9Zr9s="
+  [mod."github.com/oklog/run"]
+    version = "v1.1.0"
+    hash = "sha256-U4IS0keJa4BSBSeEBqtIV1Zg6N4b0zFiKfzN9ua4pWQ="
+  [mod."github.com/pmezard/go-difflib"]
+    version = "v1.0.0"
+    hash = "sha256-/FtmHnaGjdvEIKAJtrUfEhV7EVo5A/eYrtdnUkuxLDA="
+  [mod."github.com/posener/complete"]
+    version = "v1.2.3"
+    hash = "sha256-/17KFHD0SsGALg9iLXNIdvVFcotOO+H6bOOD5SY0MVs="
+  [mod."github.com/russross/blackfriday"]
+    version = "v1.6.0"
+    hash = "sha256-tyqVArfv2d9sKGaG83SyZm//5QxLtGp1+qLgaz0SwAw="
+  [mod."github.com/shopspring/decimal"]
+    version = "v1.3.1"
+    hash = "sha256-MA3RmMQKPrposbqXcHdvAJL50O1WsIe0EBd7rMSWPPA="
+  [mod."github.com/spf13/cast"]
+    version = "v1.5.0"
+    hash = "sha256-Pdp+wC5FWqyJKzyYHb7JCcV9BoJk/sxQw6nLyuLJvuQ="
+  [mod."github.com/stretchr/testify"]
+    version = "v1.9.0"
+    hash = "sha256-uUp/On+1nK+lARkTVtb5RxlW15zxtw2kaAFuIASA+J0="
+  [mod."github.com/vektah/gqlparser/v2"]
+    version = "v2.5.11"
+    hash = "sha256-lh25/VSjgpoM7P4zUg6MOSiA4j438STUyLKd18XkpEI="
+  [mod."github.com/vmihailenco/msgpack"]
+    version = "v4.0.4+incompatible"
+    hash = "sha256-gA3l8Ma1XVja+C8XJzgRTQVb1htbsh4yrbnOu6cuw9U="
+  [mod."github.com/vmihailenco/msgpack/v5"]
+    version = "v5.4.1"
+    hash = "sha256-pDplX6xU6UpNLcFbO1pRREW5vCnSPvSU+ojAwFDv3Hk="
+  [mod."github.com/vmihailenco/tagparser/v2"]
+    version = "v2.0.0"
+    hash = "sha256-M9QyaKhSmmYwsJk7gkjtqu9PuiqZHSmTkous8VWkWY0="
+  [mod."github.com/yuin/goldmark"]
+    version = "v1.6.0"
+    hash = "sha256-0PeGjGxxM7lUSx2dn8yPUBpilPQzEN9nkgf3s+5zGTY="
+  [mod."github.com/yuin/goldmark-meta"]
+    version = "v1.1.0"
+    hash = "sha256-Q/kRP4rpS3r24HYBvPTiuKNbf+PUMVsEp2m6yOblth0="
+  [mod."github.com/zclconf/go-cty"]
+    version = "v1.14.4"
+    hash = "sha256-Pc54uTUUxMTROex41VWFYu6pAqUxCDACAuDdMMwiW1g="
+  [mod."golang.org/x/crypto"]
+    version = "v0.22.0"
+    hash = "sha256-2+u9nd32+Bi7EEv7QFc12CRTbfV7DApNv+yKIr7+lTw="
+  [mod."golang.org/x/exp"]
+    version = "v0.0.0-20240222234643-814bf88cf225"
+    hash = "sha256-DM6/KUjyqyuqXai7UH1vMsoKXQAlYfcHTwK1dHqjRAc="
+  [mod."golang.org/x/mod"]
+    version = "v0.17.0"
+    hash = "sha256-CLaPeF6uTFuRDv4oHwOQE6MCMvrzkUjWN3NuyywZjKU="
+  [mod."golang.org/x/net"]
+    version = "v0.24.0"
+    hash = "sha256-w1c21ljta5wNIyel9CSIn/crPzwOCRofNKhqmfs4aEQ="
+  [mod."golang.org/x/sync"]
+    version = "v0.7.0"
+    hash = "sha256-2ETllEu2GDWoOd/yMkOkLC2hWBpKzbVZ8LhjLu0d2A8="
+  [mod."golang.org/x/sys"]
+    version = "v0.19.0"
+    hash = "sha256-cmuL31TYLJmDm/fDnI2Sn0wB88cpdOHV1+urorsJWx4="
+  [mod."golang.org/x/text"]
+    version = "v0.14.0"
+    hash = "sha256-yh3B0tom1RfzQBf1RNmfdNWF1PtiqxV41jW1GVS6JAg="
+  [mod."golang.org/x/tools"]
+    version = "v0.20.0"
+    hash = "sha256-g5T5FrNPO/cf2W1lc+/93FcFB3HftPjqI72FueD9Wt8="
+  [mod."google.golang.org/appengine"]
+    version = "v1.6.8"
+    hash = "sha256-decMa0MiWfW/Bzr8QPPzzpeya0YWGHhZAt4Cr/bD1wQ="
+  [mod."google.golang.org/genproto/googleapis/rpc"]
+    version = "v0.0.0-20240415180920-8c6c420018be"
+    hash = "sha256-P5SBku16dYnK4koUQxTeGwPxAAWH8rxbDm2pOzFLo/Q="
+  [mod."google.golang.org/grpc"]
+    version = "v1.63.2"
+    hash = "sha256-RmtVjYLam97k7IHTHU7Gn16xNX+GvA9AiLKlQwOiZXU="
+  [mod."google.golang.org/protobuf"]
+    version = "v1.33.0"
+    hash = "sha256-cWwQjtUwSIEkAlAadrlxK1PYZXTRrV4NKzt7xDpJgIU="
+  [mod."gopkg.in/yaml.v2"]
+    version = "v2.4.0"
+    hash = "sha256-uVEGglIedjOIGZzHW4YwN1VoRSTK8o0eGZqzd+TNdd0="
+  [mod."gopkg.in/yaml.v3"]
+    version = "v3.0.1"
+    hash = "sha256-FqL9TKYJ0XkNwJFnq9j0VvJ5ZUU1RvH/52h/f5bkYAU="

--- a/image.nix
+++ b/image.nix
@@ -1,7 +1,7 @@
 { pkgs, app, name, version, ... }:
 pkgs.dockerTools.buildImage {
   name = "docker.io/timescale/${name}";
-  tag = version;
+  tag = "v${version}-${pkgs.system}";
 
   copyToRoot = pkgs.buildEnv {
     name = "image-root";

--- a/image.nix
+++ b/image.nix
@@ -1,0 +1,17 @@
+{ pkgs, app, name, version, ... }:
+pkgs.dockerTools.buildImage {
+  name = "docker.io/timescale/${name}";
+  tag = version;
+
+  copyToRoot = pkgs.buildEnv {
+    name = "image-root";
+    pathsToLink = [ "/bin" ];
+    paths = [ app ];
+  };
+  created = "now";
+
+  config = {
+    WorkingDir = "${app}";
+    Entrypoint = [ "./bin/${name}" ];
+  };
+}

--- a/internal/client/vpc.go
+++ b/internal/client/vpc.go
@@ -5,9 +5,8 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/big"
-
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"math/big"
 )
 
 type VPC struct {

--- a/internal/provider/peering_conn_resource_test.go
+++ b/internal/provider/peering_conn_resource_test.go
@@ -25,7 +25,7 @@ func TestPeeringConnResource_Default_Success(t *testing.T) {
 			// Create the VPC
 			{
 				Config: getVPCConfig(t, config.WithName("vpc-for-pc").WithCIDR("10.0.0.0/21").WithRegionCode("us-east-1")),
-				Check: func(s *terraform.State) error {
+				Check: func(_ *terraform.State) error {
 					time.Sleep(10 * time.Second)
 					return nil
 				},
@@ -34,7 +34,7 @@ func TestPeeringConnResource_Default_Success(t *testing.T) {
 			{
 				Config: getVPCConfig(t, config.WithName("vpc-for-pc").WithCIDR("10.0.0.0/21").WithRegionCode("us-east-1")) + getPeeringConnConfig(t, pcConfig.WithVpcResourceName(config.ResourceName)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					func(s *terraform.State) error {
+					func(_ *terraform.State) error {
 						time.Sleep(10 * time.Second)
 						return nil
 					},
@@ -51,7 +51,7 @@ func TestPeeringConnResource_Default_Success(t *testing.T) {
 			{
 				Config: getVPCConfig(t, config.WithName("vpc-for-pc").WithCIDR("10.0.0.0/21").WithRegionCode("us-east-1")),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					func(s *terraform.State) error {
+					func(_ *terraform.State) error {
 						time.Sleep(10 * time.Second)
 						return nil
 					},

--- a/internal/provider/service_resource_test.go
+++ b/internal/provider/service_resource_test.go
@@ -284,7 +284,7 @@ func TestServiceResource_Import(t *testing.T) {
 			// Import the resource. This step compares the resource attributes for "test" defined above with the imported resource
 			// "test_import" defined in the config for this step. This check is done by specifying the ImportStateVerify configuration option.
 			{
-				Check: func(s *terraform.State) error {
+				Check: func(_ *terraform.State) error {
 					time.Sleep(10 * time.Second)
 					return nil
 				},

--- a/internal/provider/vpc_resource_test.go
+++ b/internal/provider/vpc_resource_test.go
@@ -24,7 +24,7 @@ func TestVPCResource_Default_Success(t *testing.T) {
 			{
 				Config: getVPCConfig(t, config.WithName("vpc-1").WithCIDR("10.0.0.0/21").WithRegionCode("us-east-1")),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					func(s *terraform.State) error {
+					func(_ *terraform.State) error {
 						time.Sleep(10 * time.Second)
 						return nil
 					},
@@ -62,7 +62,7 @@ func TestVPCResource_Import(t *testing.T) {
 			// Create the VPC to import
 			{
 				Config: getVPCConfig(t, config.WithName("import-test").WithCIDR("10.0.0.0/21").WithRegionCode("us-east-1")),
-				Check: func(s *terraform.State) error {
+				Check: func(_ *terraform.State) error {
 					time.Sleep(10 * time.Second)
 					return nil
 				},

--- a/internal/provider/vpcs_data_source_test.go
+++ b/internal/provider/vpcs_data_source_test.go
@@ -15,7 +15,7 @@ func TestVPCDataSource(t *testing.T) {
 			// Read testing
 			{
 				Config: getVPCConfig(t, config.WithName("data-source-test").WithCIDR("10.0.0.0/21").WithRegionCode("us-east-1")),
-				Check: func(s *terraform.State) error {
+				Check: func(_ *terraform.State) error {
 					time.Sleep(5 * time.Second)
 					return nil
 				},

--- a/main.go
+++ b/main.go
@@ -13,19 +13,23 @@ import (
 //go:generate terraform fmt -recursive ./examples/
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
-var (
-	// these will be set by the goreleaser configuration
-	// to appropriate values for the compiled binary
-	version = "dev"
+// foo
+// these will be set by the goreleaser configuration
+// to appropriate values for the compiled binary
+var version = "dev"
 
-	// goreleaser can also pass the specific commit if you want
-	// commit  string = ""
-)
+// goreleaser can also pass the specific commit if you want
+// commit  string = ""
 
 func main() {
 	var debug bool
 
-	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.BoolVar(
+		&debug,
+		"debug",
+		false,
+		"set to true to run the provider with support for debuggers like delve",
+	)
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
@@ -34,7 +38,6 @@ func main() {
 	}
 
 	err := providerserver.Serve(context.Background(), provider.New(version), opts)
-
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 //go:generate terraform fmt -recursive ./examples/
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
-// foo
 // these will be set by the goreleaser configuration
 // to appropriate values for the compiled binary
 var version = "dev"


### PR DESCRIPTION
TL;DR;  this PR uses a tool called https://devenv.sh that adds support to run the ci tasks locally.
## Changes

What it does:
- [x] builds the go app with nix
- [x] builds the go with gomod2nix
- [x] add pre-commits checks like:
  - [x] `govet`
  - [x] `golangci-lint`
  - [x] `go tests`
- [x] have all ci actions run though devenv


What is missing:
- [x] fix the vpc error that is not related
- [x] update the branch protection rules to reflect the new job names

what is optional but cool:
- [x] build docker images using same binary built
- [ ] build multi-arch images for `x86_64` and `aarch64`
- [ ] push images to the registry

## Usage

> [!IMPORTANT]
> The pre-commit hooks will prevent committing if they fail.
>  <img width="1043" alt="image" src="https://github.com/user-attachments/assets/0bdea7a9-046a-490b-a8b4-e604794939be">


Start by installing devenv: https://devenv.sh/getting-started/

to build the packages:

```shell
devenv build
```

to run tests and all pre-commit checks:

```shell
devenv test
````

to run a dev environment with all tools installed and configured:

```shell
devenv shell
```


TODO:
- [ ] update readme with details about how to use it and install it at the read me
- [ ] remove docker image that is not useful/necessary