### PR TITLE
Populate read_replica_source when reading the replica

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,4 +74,4 @@ jobs:
           TF_VAR_ts_aws_acc_id: ${{ secrets.TF_VAR_TS_AWS_ACC_ID }}
           # point to API
           TIMESCALE_DEV_URL: ${{ secrets.TIMESCALE_DEV_URL }}
-        run: go test -v -cover ./internal/provider/
+        run: go test -timeout 120m -v -cover ./internal/provider/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     name: Terraform Provider Acceptance Tests
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -75,4 +75,3 @@ jobs:
           # point to API
           TIMESCALE_DEV_URL: ${{ secrets.TIMESCALE_DEV_URL }}
         run: go test -v -cover ./internal/provider/
-        timeout-minutes: 10

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -647,6 +647,9 @@ func serviceToResource(diag diag.Diagnostics, s *tsClient.Service, state service
 	if s.Metadata != nil {
 		model.EnvironmentTag = types.StringValue(s.Metadata.Environment)
 	}
+	if s.ForkSpec != nil && s.ForkSpec.IsStandby {
+		model.ReadReplicaSource = types.StringValue(s.ForkSpec.ServiceID)
+	}
 
 	if s.Endpoints != nil {
 		if s.Endpoints.Primary != nil && s.Endpoints.Primary.Host != "" {


### PR DESCRIPTION
When we getService on a read replica, we need to populate the read_replica_source to properly reflect that information in terraform state

closes https://github.com/timescale/Support-Dev-Collab/issues/2063