### PR TITLE
Update releaser version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
+          version: '~> v2'
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
   push:
     paths-ignore:
       - 'README.md'
+      - '.github/workflows/**'
 
 # Testing only needs permissions to read the repository contents.
 permissions:


### PR DESCRIPTION
After releaser has been updated, we need to specify its configuration version explicitly:
https://github.com/goreleaser/goreleaser-action
That is to mitigate the release failure
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/c0a76d77-5ae1-4411-9b38-c14b1474d902">
