### PR TITLE
fix vpc creation error

### DIFF
--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -169,7 +170,7 @@ func (c *Client) CreateService(ctx context.Context, request CreateServiceRequest
 	if err := c.do(ctx, req, &resp); err != nil {
 		return nil, err
 	}
-	if len(resp.Errors) > 0 {
+	if len(resp.Errors) > 0 && !strings.Contains(resp.Errors[0].Message, "no Endpoint for that service id exists") {
 		return nil, resp.Errors[0]
 	}
 	if resp.Data == nil {

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -333,6 +333,10 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 	}
 
+	if !plan.VpcID.IsNull() {
+		request.VpcID = plan.VpcID.ValueInt64()
+	}
+
 	response, err := r.client.CreateService(ctx, request)
 
 	if err != nil {
@@ -352,19 +356,6 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		if err != nil {
 			resp.Diagnostics.AddWarning("Error Deleting Resource", "error occurred attempting to delete the resource that timed out, please check your Timescale account to verify there is no unexpected service running from Terraform")
 		}
-		return
-	}
-
-	service, err = r.attachNewServiceToVPC(ctx, plan, service)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to attach service to VPC", err.Error())
-
-		// Attempt to delete the service to avoid leaving an instance in an inconsistent state
-		_, deleteErr := r.client.DeleteService(context.Background(), response.Service.ID)
-		if deleteErr != nil {
-			resp.Diagnostics.AddWarning("Error Deleting Resource", fmt.Sprintf("Failed to delete service after attach to vpc error; Remove orphaned resources from your account manually. Error: %s", deleteErr))
-		}
-
 		return
 	}
 
@@ -389,21 +380,6 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		tflog.Error(ctx, fmt.Sprintf("error updating terraform state %v", resp.Diagnostics.Errors()))
 		return
 	}
-}
-
-func (r *ServiceResource) attachNewServiceToVPC(ctx context.Context, plan serviceResourceModel, service *tsClient.Service) (*tsClient.Service, error) {
-	// Add service to vpc if vpc_id is provided
-	if plan.VpcID.IsNull() {
-		return service, nil
-	}
-
-	err := r.client.AttachServiceToVPC(ctx, service.ID, plan.VpcID.ValueInt64())
-	if err != nil {
-		return nil, fmt.Errorf("failed to attach service to VPC: %w", err)
-	}
-
-	// Now wait for the service to be ready after attaching to VPC.
-	return r.waitForServiceReadiness(ctx, service.ID, plan.Timeouts)
 }
 
 func (r *ServiceResource) validateCreateReadReplicaRequest(ctx context.Context, primary *tsClient.Service, plan serviceResourceModel) error {


### PR DESCRIPTION
this commit changes the create service call, removing the vpc id, then after creation call the attach_vpc and wait for the service get ready.

**Issues**

Use "closes #XX" to have the issue closed when this merged.

**Related PRs**

Any related PRs from other repos or branches

**Checklist**
- [ ] Well formatted git commit message (see [these guidelines](https://chris.beams.io/posts/git-commit/))
- [ ] Unit test coverage of new code
- [ ] Document new features to the main README
