### PR TITLE
Pin runner image to ubuntu-22.04

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   # Ensure project builds before running testing matrix
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4 # v3.3.0
@@ -30,7 +30,7 @@ jobs:
       - run: go build -v .
 
   generate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4 # v3.3.0
       - uses: actions/setup-go@v5 # v4.0.0
@@ -47,7 +47,7 @@ jobs:
   test:
     name: Terraform Provider Acceptance Tests
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
Previous image was ubuntu-latest, which was changed to ubuntu-24.04 recently and since it doesn't include terraform anymore, CI started failing. To fix it for ubuntu24.04 we'd need to add a separate step to setup TF in the image.