### PR TITLE
Specify accepter region

### DIFF
--- a/templates/index.md
+++ b/templates/index.md
@@ -80,6 +80,11 @@ provider "timescale" {
   secret_key = var.ts_secret_key
 }
 
+provider "aws" {
+  alias  = "peer"
+  region = "us-east-1"
+}
+
 variable "aws_account_id" {
   type = string
 }
@@ -127,6 +132,7 @@ resource "timescale_peering_connection" "peer" {
 
 # Accepter's side of the peering connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
+  provider                  = aws.peer
   vpc_peering_connection_id = timescale_peering_connection.peer.provisioned_id
   auto_accept               = true
 


### PR DESCRIPTION
Set the accepter region to avoid `pcx not found` errors when using a region other than the default one (`us-east-1`).