### PR TITLE
Specify provider region

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 linters-settings:
   govet:
-    check-shadowing: false
     settings:
       printf:
         funcs:

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ provider "timescale" {
 
 // If you have multiple regions, you’ll need to use multiple `provider` configurations.
 provider "aws" {
-  region = "us-east-1"
+  region = var.aws_region
 }
 
 variable "aws_account_id" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,7 +80,7 @@ provider "timescale" {
   secret_key = var.ts_secret_key
 }
 
-// If you have multiple regions, you’ll need to use multiple `provider` configurations.
+# If you have multiple regions, you’ll need to use multiple `provider` configurations.
 provider "aws" {
   region = var.aws_region
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ provider "timescale" {
   secret_key = var.ts_secret_key
 }
 
+// If you have multiple regions, you’ll need to use multiple `provider` configurations.
 provider "aws" {
   region = "us-east-1"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,6 @@ provider "timescale" {
 }
 
 provider "aws" {
-  alias  = "peer"
   region = "us-east-1"
 }
 
@@ -132,7 +131,6 @@ resource "timescale_peering_connection" "peer" {
 
 # Accepter's side of the peering connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
-  provider                  = aws.peer
   vpc_peering_connection_id = timescale_peering_connection.peer.provisioned_id
   auto_accept               = true
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,11 @@ provider "timescale" {
   secret_key = var.ts_secret_key
 }
 
+provider "aws" {
+  alias  = "peer"
+  region = "us-east-1"
+}
+
 variable "aws_account_id" {
   type = string
 }
@@ -127,6 +132,7 @@ resource "timescale_peering_connection" "peer" {
 
 # Accepter's side of the peering connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
+  provider                  = aws.peer
   vpc_peering_connection_id = timescale_peering_connection.peer.provisioned_id
   auto_accept               = true
 

--- a/templates/index.md
+++ b/templates/index.md
@@ -82,7 +82,7 @@ provider "timescale" {
 
 // If you have multiple regions, you’ll need to use multiple `provider` configurations.
 provider "aws" {
-  region = "us-east-1"
+  region = var.aws_region
 }
 
 variable "aws_account_id" {

--- a/templates/index.md
+++ b/templates/index.md
@@ -80,7 +80,7 @@ provider "timescale" {
   secret_key = var.ts_secret_key
 }
 
-// If you have multiple regions, you’ll need to use multiple `provider` configurations.
+# If you have multiple regions, you’ll need to use multiple `provider` configurations.
 provider "aws" {
   region = var.aws_region
 }

--- a/templates/index.md
+++ b/templates/index.md
@@ -80,6 +80,7 @@ provider "timescale" {
   secret_key = var.ts_secret_key
 }
 
+// If you have multiple regions, you’ll need to use multiple `provider` configurations.
 provider "aws" {
   region = "us-east-1"
 }

--- a/templates/index.md
+++ b/templates/index.md
@@ -81,7 +81,6 @@ provider "timescale" {
 }
 
 provider "aws" {
-  alias  = "peer"
   region = "us-east-1"
 }
 
@@ -132,7 +131,6 @@ resource "timescale_peering_connection" "peer" {
 
 # Accepter's side of the peering connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
-  provider                  = aws.peer
   vpc_peering_connection_id = timescale_peering_connection.peer.provisioned_id
   auto_accept               = true
 

--- a/templates/index.md
+++ b/templates/index.md
@@ -80,6 +80,11 @@ provider "timescale" {
   secret_key = var.ts_secret_key
 }
 
+provider "aws" {
+  alias  = "peer"
+  region = "us-east-1"
+}
+
 variable "aws_account_id" {
   type = string
 }
@@ -127,6 +132,7 @@ resource "timescale_peering_connection" "peer" {
 
 # Accepter's side of the peering connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
+  provider                  = aws.peer
   vpc_peering_connection_id = timescale_peering_connection.peer.provisioned_id
   auto_accept               = true
 


### PR DESCRIPTION
Set the provider region to avoid `pcx not found` errors.