### PR TITLE
fix: namespace S3 connector GraphQL operations under connectors root …

### DIFF
--- a/internal/client/queries/connector_s3_create.graphql
+++ b/internal/client/queries/connector_s3_create.graphql
@@ -1,15 +1,17 @@
 mutation CreateS3Connector($id: ID!, $projectId: ID!, $serviceId: ID!, $bucket: String, $pattern: String, $credentials: S3LiveSyncCredentialsInput, $definition: S3LiveSyncDefinitionInput, $tableIdentifier: FileImportTableIdentifierInput, $name: String) {
-    createS3LiveSync(
-        data: {
-            id: $id
-            project_id: $projectId
-            service_id: $serviceId
-            bucket: $bucket
-            pattern: $pattern
-            credentials: $credentials
-            definition: $definition
-            table_identifier: $tableIdentifier
-            name: $name
-        }
-    )
+    connectors {
+        createS3LiveSync(
+            data: {
+                id: $id
+                project_id: $projectId
+                service_id: $serviceId
+                bucket: $bucket
+                pattern: $pattern
+                credentials: $credentials
+                definition: $definition
+                table_identifier: $tableIdentifier
+                name: $name
+            }
+        )
+    }
 }

--- a/internal/client/queries/connector_s3_delete.graphql
+++ b/internal/client/queries/connector_s3_delete.graphql
@@ -1,9 +1,11 @@
 mutation DeleteS3Connector($id: ID!, $projectId: ID!, $serviceId: ID!) {
-    deleteS3LiveSync(
-        data: {
-            id: $id
-            project_id: $projectId
-            service_id: $serviceId
-        }
-    )
+    connectors {
+        deleteS3LiveSync(
+            data: {
+                id: $id
+                project_id: $projectId
+                service_id: $serviceId
+            }
+        )
+    }
 }

--- a/internal/client/queries/connector_s3_get.graphql
+++ b/internal/client/queries/connector_s3_get.graphql
@@ -1,56 +1,58 @@
 query GetS3Connector($id: ID!, $projectId: ID!, $serviceId: ID!) {
-    getS3LiveSync(
-        data: {
-            id: $id
-            project_id: $projectId
-            service_id: $serviceId
-        }
-    ) {
-        id
-        project_id
-        service_id
-        created_at
-        updated_at
-        bucket
-        pattern
-        credentials {
-            type
-            role {
-                arn
+    connectors {
+        getS3LiveSync(
+            data: {
+                id: $id
+                project_id: $projectId
+                service_id: $serviceId
             }
-        }
-        definition {
-            type
-            csv {
-                delimiter
-                skip_header
-                column_names
-                column_mappings {
-                    source
-                    destination
+        ) {
+            id
+            project_id
+            service_id
+            created_at
+            updated_at
+            bucket
+            pattern
+            credentials {
+                type
+                role {
+                    arn
                 }
-                auto_column_mapping
             }
-            parquet {
-                column_mappings {
-                    source
-                    destination
+            definition {
+                type
+                csv {
+                    delimiter
+                    skip_header
+                    column_names
+                    column_mappings {
+                        source
+                        destination
+                    }
+                    auto_column_mapping
                 }
-                auto_column_mapping
+                parquet {
+                    column_mappings {
+                        source
+                        destination
+                    }
+                    auto_column_mapping
+                }
             }
-        }
-        table_identifier {
-            schema_name
-            table_name
-        }
-        frequency
-        next_tick
-        last_imported_object
-        enabled
-        name
-        last_error
-        settings {
-            on_conflict_do_nothing
+            table_identifier {
+                schema_name
+                table_name
+            }
+            frequency
+            next_tick
+            last_imported_object
+            enabled
+            name
+            last_error
+            settings {
+                on_conflict_do_nothing
+            }
         }
     }
 }

--- a/internal/client/queries/connector_s3_update.graphql
+++ b/internal/client/queries/connector_s3_update.graphql
@@ -1,57 +1,59 @@
 mutation UpdateS3Connector($id: ID!, $projectId: ID!, $serviceId: ID!, $requests: [S3LiveSyncUpdateRequest!]!) {
-    updateS3LiveSync(
-        data: {
-            id: $id
-            project_id: $projectId
-            service_id: $serviceId
-            requests: $requests
-        }
-    ) {
-        id
-        project_id
-        service_id
-        created_at
-        updated_at
-        bucket
-        pattern
-        credentials {
-            type
-            role {
-                arn
+    connectors {
+        updateS3LiveSync(
+            data: {
+                id: $id
+                project_id: $projectId
+                service_id: $serviceId
+                requests: $requests
             }
-        }
-        definition {
-            type
-            csv {
-                delimiter
-                skip_header
-                column_names
-                column_mappings {
-                    source
-                    destination
+        ) {
+            id
+            project_id
+            service_id
+            created_at
+            updated_at
+            bucket
+            pattern
+            credentials {
+                type
+                role {
+                    arn
                 }
-                auto_column_mapping
             }
-            parquet {
-                column_mappings {
-                    source
-                    destination
+            definition {
+                type
+                csv {
+                    delimiter
+                    skip_header
+                    column_names
+                    column_mappings {
+                        source
+                        destination
+                    }
+                    auto_column_mapping
                 }
-                auto_column_mapping
+                parquet {
+                    column_mappings {
+                        source
+                        destination
+                    }
+                    auto_column_mapping
+                }
             }
-        }
-        table_identifier {
-            schema_name
-            table_name
-        }
-        frequency
-        next_tick
-        last_imported_object
-        enabled
-        name
-        last_error
-        settings {
-            on_conflict_do_nothing
+            table_identifier {
+                schema_name
+                table_name
+            }
+            frequency
+            next_tick
+            last_imported_object
+            enabled
+            name
+            last_error
+            settings {
+                on_conflict_do_nothing
+            }
         }
     }
 }

--- a/internal/client/s3_connector.go
+++ b/internal/client/s3_connector.go
@@ -126,19 +126,27 @@ type S3ConnectorUpdateRequest struct {
 
 // Response types.
 type CreateS3ConnectorResponse struct {
-	CreateS3LiveSync string `json:"createS3LiveSync"`
+	Connectors struct {
+		CreateS3LiveSync string `json:"createS3LiveSync"`
+	} `json:"connectors"`
 }
 
 type UpdateS3ConnectorResponse struct {
-	Connector *S3Connector `json:"updateS3LiveSync"`
+	Connectors struct {
+		Connector *S3Connector `json:"updateS3LiveSync"`
+	} `json:"connectors"`
 }
 
 type GetS3ConnectorResponse struct {
-	Connector *S3Connector `json:"getS3LiveSync"`
+	Connectors struct {
+		Connector *S3Connector `json:"getS3LiveSync"`
+	} `json:"connectors"`
 }
 
 type DeleteS3ConnectorResponse struct {
-	DeleteS3LiveSync string `json:"deleteS3LiveSync"`
+	Connectors struct {
+		DeleteS3LiveSync string `json:"deleteS3LiveSync"`
+	} `json:"connectors"`
 }
 
 // CreateS3Connector creates a new S3 connector (returns success only).
@@ -214,11 +222,11 @@ func (c *Client) UpdateS3Connector(ctx context.Context, id, projectID, serviceID
 	if len(resp.Errors) > 0 {
 		return nil, fmt.Errorf("API returned an error: %w", resp.Errors[0])
 	}
-	if resp.Data == nil || resp.Data.Connector == nil {
+	if resp.Data == nil || resp.Data.Connectors.Connector == nil {
 		return nil, errors.New("API response did not contain connector data")
 	}
 
-	return resp.Data.Connector, nil
+	return resp.Data.Connectors.Connector, nil
 }
 
 // GetS3Connector retrieves an S3 connector by ID.
@@ -242,11 +250,11 @@ func (c *Client) GetS3Connector(ctx context.Context, id, projectID, serviceID st
 	if len(resp.Errors) > 0 {
 		return nil, fmt.Errorf("API returned an error: %w", resp.Errors[0])
 	}
-	if resp.Data == nil || resp.Data.Connector == nil {
+	if resp.Data == nil || resp.Data.Connectors.Connector == nil {
 		return nil, errors.New("connector not found")
 	}
 
-	return resp.Data.Connector, nil
+	return resp.Data.Connectors.Connector, nil
 }
 
 // DeleteS3Connector deletes an S3 connector.


### PR DESCRIPTION
…field

The S3 connector mutations and queries are defined under the ConnectorsMutator and ConnectorsQuerier types in the GraphQL schema, requiring them to be nested under a `connectors` root field. While the API currently exposes these at the root level via the csv-importer schema, this aligns with the canonical schema and ensures forward compatibility.

**Issues**

Use "closes #XX" to have the issue closed when this merged.

**Related PRs**

Any related PRs from other repos or branches

**Checklist**
- [ ] Well formatted git commit message (see [these guidelines](https://chris.beams.io/posts/git-commit/))
- [ ] Acceptance test coverage of new code
- [ ] Document new features in README.md and/or templates/index.md
- [ ] Run `make` locally to generate docs and add them to this PR
