### PR TITLE
fix: extend milli_cpu and memory_gb validation to support larger instance sizes

### DIFF
--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -52,8 +52,8 @@ const (
 )
 
 var (
-	memorySizes   = []int64{2, 4, 8, 16, 32, 64, 128}
-	milliCPUSizes = []int64{500, 1000, 2000, 4000, 8000, 16000, 32000}
+	memorySizes   = []int64{2, 4, 8, 16, 32, 64, 128, 192, 256}
+	milliCPUSizes = []int64{500, 1000, 2000, 4000, 8000, 16000, 32000, 48000, 64000}
 )
 
 func NewServiceResource() resource.Resource {


### PR DESCRIPTION
## Summary

Adds 48000 and 64000 to allowed `milli_cpu` values and 192 and 256 to allowed `memory_gb` values in the `timescale_service` resource validator.

Fixes #345

## Problem

The `OneOf` validators for `milli_cpu` and `memory_gb` are hardcoded to a subset of instance sizes. The Timescale Cloud API supports larger tiers (48 vCPU / 192 GB and 64 vCPU / 256 GB), but the provider rejects these values during plan/apply, making it impossible to manage services at those sizes with Terraform.

## Changes

**`internal/provider/service_resource.go`**:
- `milliCPUSizes`: added 48000, 64000
- `memorySizes`: added 192, 256

## Testing

This is a validation-only change — no API behavior is affected. The API already accepts these values when creating or resizing services.