### PR TITLE
feat: add data_tiering_enabled attribute to timescale_service

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -98,6 +98,7 @@ resource "timescale_service" "secure" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `connection_pooler_enabled` (Boolean) Set connection pooler status for this service.
+- `data_tiering_enabled` (Boolean) Enable [data tiering](https://docs.timescale.com/use-timescale/latest/data-tiering/) (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only. When set to `true`, the OSM functions (`add_tiering_policy`, `tier_chunk`, `remove_tiering_policy`) become available on the service.
 - `enable_ha_replica` (Boolean, Deprecated) Enable HA Replica (deprecated - use ha_replicas and sync_replicas instead)
 - `environment_tag` (String) Set environment tag for this service.
 - `ha_replicas` (Number) Number of HA replicas (0, 1 or 2). Modes: 1 for 'High availability'; 2 'Highest availability'. Async replicas (i.e. 'High performance' mode) will be created by default if sync_replicas is not set.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -30,6 +30,8 @@ var (
 	ToggleServiceMutation string
 	//go:embed queries/toggle_connection_pooler.graphql
 	ToggleConnectionPoolerMutation string
+	//go:embed queries/toggle_data_tiering.graphql
+	ToggleDataTieringMutation string
 	//go:embed queries/set_env_tag.graphql
 	SetEnvironmentTagMutation string
 	//go:embed queries/get_all_services.graphql

--- a/internal/client/queries/create_service.graphql
+++ b/internal/client/queries/create_service.graphql
@@ -48,6 +48,9 @@ mutation CreateService($projectId: ID!, $name: String!, $type: Type!, $resourceC
             metadata {
                 environment
             }
+            dataTieringSettings {
+                enabled
+            }
             endpoints {
                 primary {
                     host

--- a/internal/client/queries/get_all_services.graphql
+++ b/internal/client/queries/get_all_services.graphql
@@ -47,6 +47,9 @@ query GetAllServices($projectId: ID!) {
         metadata {
             environment
         }
+        dataTieringSettings {
+            enabled
+        }
         endpoints {
             primary {
                 host

--- a/internal/client/queries/get_service.graphql
+++ b/internal/client/queries/get_service.graphql
@@ -50,6 +50,9 @@ query GetService($projectId: ID!, $serviceId: ID!) {
         metadata {
             environment
         }
+        dataTieringSettings {
+            enabled
+        }
         endpoints {
             primary {
                 host

--- a/internal/client/queries/toggle_data_tiering.graphql
+++ b/internal/client/queries/toggle_data_tiering.graphql
@@ -1,0 +1,7 @@
+mutation ToggleDataTiering($projectId: ID!, $serviceId: ID!, $enable: Boolean!) {
+    toggleDataTiering (data:{
+        serviceId: $serviceId,
+        projectId: $projectId,
+        enable: $enable
+    })
+}

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -12,19 +12,20 @@ import (
 )
 
 type Service struct {
-	ID            string         `json:"id"`
-	ProjectID     string         `json:"projectId"`
-	Name          string         `json:"name"`
-	Status        string         `json:"status"`
-	RegionCode    string         `json:"regionCode"`
-	Paused        bool           `json:"paused"`
-	ServiceSpec   ServiceSpec    `json:"spec"`
-	Resources     []ResourceSpec `json:"resources"`
-	Created       string         `json:"created"`
-	ReplicaStatus string         `json:"replicaStatus"`
-	VPCEndpoint   *VPCEndpoint   `json:"vpcEndpoint"`
-	ForkSpec      *ForkSpec      `json:"forkedFromId"`
-	Metadata      *Metadata      `json:"metadata"`
+	ID                  string               `json:"id"`
+	ProjectID           string               `json:"projectId"`
+	Name                string               `json:"name"`
+	Status              string               `json:"status"`
+	RegionCode          string               `json:"regionCode"`
+	Paused              bool                 `json:"paused"`
+	ServiceSpec         ServiceSpec          `json:"spec"`
+	Resources           []ResourceSpec       `json:"resources"`
+	Created             string               `json:"created"`
+	ReplicaStatus       string               `json:"replicaStatus"`
+	VPCEndpoint         *VPCEndpoint         `json:"vpcEndpoint"`
+	ForkSpec            *ForkSpec            `json:"forkedFromId"`
+	Metadata            *Metadata            `json:"metadata"`
+	DataTieringSettings *DataTieringSettings `json:"dataTieringSettings"`
 
 	// Endpoints contains the all service endpoints
 	Endpoints *ServiceEndpoints `json:"endpoints,omitempty"`
@@ -60,6 +61,12 @@ type ResourceSpec struct {
 
 type Metadata struct {
 	Environment string `json:"environment"`
+}
+
+// DataTieringSettings reflects dataTieringSettings on the Service object.
+// When tiered storage is enabled on the service (Scale/Enterprise plan), Enabled is true.
+type DataTieringSettings struct {
+	Enabled bool `json:"enabled"`
 }
 
 type CreateServiceRequest struct {
@@ -395,6 +402,30 @@ func (c *Client) ToggleConnectionPooler(ctx context.Context, serviceID string, e
 	req := map[string]interface{}{
 		"operationName": "ToggleConnectionPooler",
 		"query":         ToggleConnectionPoolerMutation,
+		"variables": map[string]any{
+			"projectId": c.projectID,
+			"serviceId": serviceID,
+			"enable":    enable,
+		},
+	}
+	var resp Response[any]
+	if err := c.do(ctx, req, &resp); err != nil {
+		return err
+	}
+	if len(resp.Errors) > 0 {
+		return resp.Errors[0]
+	}
+	if resp.Data == nil {
+		return errors.New("no response found")
+	}
+	return nil
+}
+
+func (c *Client) ToggleDataTiering(ctx context.Context, serviceID string, enable bool) error {
+	tflog.Trace(ctx, "Client.ToggleDataTiering")
+	req := map[string]interface{}{
+		"operationName": "ToggleDataTiering",
+		"query":         ToggleDataTieringMutation,
 		"variables": map[string]any{
 			"projectId": c.projectID,
 			"serviceId": serviceID,

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -92,6 +92,7 @@ type serviceResourceModel struct {
 	ReadReplicaNodes        types.Int64    `tfsdk:"read_replica_nodes"`
 	VpcID                   types.Int64    `tfsdk:"vpc_id"`
 	ConnectionPoolerEnabled types.Bool     `tfsdk:"connection_pooler_enabled"`
+	DataTieringEnabled      types.Bool     `tfsdk:"data_tiering_enabled"`
 	EnvironmentTag          types.String   `tfsdk:"environment_tag"`
 	MetricExporterID        types.String   `tfsdk:"metric_exporter_id"`
 	LogExporterID           types.String   `tfsdk:"log_exporter_id"`
@@ -289,6 +290,16 @@ The change has been taken into account but must still be propagated. You can run
 			"connection_pooler_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Set connection pooler status for this service.",
 				Description:         "Set connection pooler status for this service.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"data_tiering_enabled": schema.BoolAttribute{
+				MarkdownDescription: "Enable [data tiering](https://docs.timescale.com/use-timescale/latest/data-tiering/) (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only. When set to `true`, the OSM functions (`add_tiering_policy`, `tier_chunk`, `remove_tiering_policy`) become available on the service.",
+				Description:         "Enable data tiering (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only.",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
@@ -570,6 +581,21 @@ func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 	}
 
+	// Data tiering — services are created with tiering disabled. If the plan asks
+	// for it enabled, toggle it on and refresh state. Toggling false on a freshly
+	// created service is a no-op so we skip the call when not requested.
+	if plan.DataTieringEnabled.ValueBool() {
+		if err := r.client.ToggleDataTiering(ctx, service.ID, true); err != nil {
+			resp.Diagnostics.AddError("Failed to enable data tiering", err.Error())
+			return
+		}
+		service, err = r.client.GetService(ctx, service.ID)
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to enable data tiering", "unable to refresh service after enabling data tiering")
+			return
+		}
+	}
+
 	resourceModel := serviceToResource(resp.Diagnostics, service, plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, resourceModel)...)
 	if resp.Diagnostics.HasError() {
@@ -736,6 +762,13 @@ func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest
 	if plan.ConnectionPoolerEnabled != state.ConnectionPoolerEnabled {
 		if err := r.client.ToggleConnectionPooler(ctx, serviceID, plan.ConnectionPoolerEnabled.ValueBool()); err != nil {
 			resp.Diagnostics.AddError("Failed to toggle connection pooler", err.Error())
+			return
+		}
+	}
+	// Data tiering /////////////////////////////////////////////
+	if plan.DataTieringEnabled != state.DataTieringEnabled {
+		if err := r.client.ToggleDataTiering(ctx, serviceID, plan.DataTieringEnabled.ValueBool()); err != nil {
+			resp.Diagnostics.AddError("Failed to toggle data tiering", err.Error())
 			return
 		}
 	}
@@ -943,6 +976,7 @@ func (r *serviceResource) ImportState(ctx context.Context, req resource.ImportSt
 
 func serviceToResource(diag diag.Diagnostics, s *tsClient.Service, state serviceResourceModel) serviceResourceModel {
 	hasPooler := s.ServiceSpec.PoolerEnabled
+	hasDataTiering := s.DataTieringSettings != nil && s.DataTieringSettings.Enabled
 	replicaCount := s.Resources[0].Spec.ReplicaCount
 	syncReplicaCount := s.Resources[0].Spec.SyncReplicaCount
 
@@ -977,6 +1011,7 @@ func serviceToResource(diag diag.Diagnostics, s *tsClient.Service, state service
 		ReadReplicaSource:       state.ReadReplicaSource,
 		ReadReplicaNodes:        readReplicaNodes,
 		ConnectionPoolerEnabled: types.BoolValue(hasPooler),
+		DataTieringEnabled:      types.BoolValue(hasDataTiering),
 		EnableHAReplica:         types.BoolNull(),
 		Hostname:                types.StringNull(),
 		Port:                    types.Int64Null(),

--- a/internal/provider/service_resource_test.go
+++ b/internal/provider/service_resource_test.go
@@ -42,6 +42,7 @@ func TestServiceResource_Default_Success(t *testing.T) {
 					resource.TestCheckResourceAttr("timescale_service.resource", "ha_replicas", "0"),
 					resource.TestCheckResourceAttr("timescale_service.resource", "sync_replicas", "0"),
 					resource.TestCheckResourceAttr("timescale_service.resource", "connection_pooler_enabled", "false"),
+					resource.TestCheckResourceAttr("timescale_service.resource", "data_tiering_enabled", "false"),
 					resource.TestCheckResourceAttr("timescale_service.resource", "environment_tag", "DEV"),
 					resource.TestCheckNoResourceAttr("timescale_service.resource", "vpc_id"),
 				),
@@ -75,6 +76,20 @@ func TestServiceResource_Default_Success(t *testing.T) {
 					resource.TestCheckResourceAttr("timescale_service.resource", "connection_pooler_enabled", "true"),
 					resource.TestCheckResourceAttrSet("timescale_service.resource", "pooler_hostname"),
 					resource.TestCheckResourceAttrSet("timescale_service.resource", "pooler_port"),
+				),
+			},
+			// Enable data tiering (requires Scale or Enterprise plan on the test project)
+			{
+				Config: getServiceConfig(t, config.WithDataTiering(true)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("timescale_service.resource", "data_tiering_enabled", "true"),
+				),
+			},
+			// Disable data tiering
+			{
+				Config: getServiceConfig(t, config.WithDataTiering(false)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("timescale_service.resource", "data_tiering_enabled", "false"),
 				),
 			},
 			// Enable HA replica (deprecated but still maintained for backwards compatibility)
@@ -567,6 +582,7 @@ type ServiceConfig struct {
 	ReadReplicaSource string
 	ReadReplicaNodes  *int64
 	Pooler            bool
+	DataTiering       bool
 	Environment       string
 	Password          string
 	PasswordWo        string
@@ -635,6 +651,11 @@ func (c *ServiceConfig) WithPooler(pooler bool) *ServiceConfig {
 	return c
 }
 
+func (c *ServiceConfig) WithDataTiering(enabled bool) *ServiceConfig {
+	c.DataTiering = enabled
+	return c
+}
+
 func (c *ServiceConfig) WithReadReplica(source string) *ServiceConfig {
 	c.ReadReplicaSource = source
 	return c
@@ -680,6 +701,9 @@ func (c *ServiceConfig) String(t *testing.T) string {
 	}
 	if c.Pooler {
 		write("connection_pooler_enabled = %t \n", c.Pooler)
+	}
+	if c.DataTiering {
+		write("data_tiering_enabled = %t \n", c.DataTiering)
 	}
 	if c.Environment != "" {
 		write("environment_tag = %q \n", c.Environment)


### PR DESCRIPTION
## Summary

Adds support for managing the Tiger Cloud **data tiering** feature directly from Terraform, via a new `data_tiering_enabled` attribute on the `timescale_service` resource.

Implements the plan outlined in #239 — same shape as the existing `connection_pooler_enabled` attribute, mirroring `ToggleConnectionPooler` end-to-end.

Closes #239.

## What's added

- `internal/client/queries/toggle_data_tiering.graphql` — new mutation file.
- `internal/client/client.go` — embed + `ToggleDataTieringMutation` variable.
- `internal/client/service.go` — `ToggleDataTiering` client method (mirror of `ToggleConnectionPooler`), `DataTieringSettings` type, new field on `Service` struct.
- `internal/client/queries/{create_service,get_service,get_all_services}.graphql` — select `dataTieringSettings { enabled }`.
- `internal/provider/service_resource.go` — `data_tiering_enabled` schema attribute (Optional + Computed, default `false`), read-mapping (handles `nil` settings for backward compatibility), conditional toggle in `Create()` (only when `true`, since services are created with tiering disabled), and conditional toggle in `Update()` (when desired value differs from state — same shape as `connection_pooler_enabled`).
- `internal/provider/service_resource_test.go` — extends `TestServiceResource_Default_Success` with default state assertion and enable/disable steps; adds `WithDataTiering` config helper.
- `templates/index.md` — example resource block updated with `data_tiering_enabled`.
- `docs/` — regenerated via `make generate`.

## Behavior

- Default value: `false` — matches the API default for newly created services.
- On create: if `data_tiering_enabled = true`, the resource calls `ToggleDataTiering` once after the service becomes ready and refreshes its state.
- On update: any change between plan and state triggers `ToggleDataTiering` with the new desired value.
- On read: populated from `dataTieringSettings.enabled` in the GraphQL response. Treats `nil` (older API responses) as `false` so existing states stay valid.
- Tiering availability requires Scale or Enterprise plans on the project — the API surfaces an error if the plan doesn't support it, which propagates through `Diagnostics.AddError`.

## Notes for reviewers

Three intentional points worth surfacing up-front to anticipate questions:

1. **`Create()` toggles after service creation** (different from ConnectionPooler, which threads `EnableConnectionPooler` through the `CreateServiceRequest` and into the `createService` mutation). The reason: the `createService` GraphQL mutation has no tiering field, so the toggle has to be issued separately after the service is ready. The toggle is conditional on `data_tiering_enabled = true` to avoid an unnecessary API call on the default path.

2. **No service cleanup on toggle failure** (mirrors the exporter-attach pattern, not the password-set pattern). If a user sets `data_tiering_enabled = true` on a project whose plan doesn't support tiering, the API rejects the toggle, the service is created but state is not persisted by Terraform — leaving an orphan service the user has to remove manually. This inherits the same limitation that already exists for `metric_exporter_id` / `log_exporter_id` attaches; happy to switch to the password-style cleanup path if that's preferred.

3. **No plan-tier validation at schema level**. Tiering requires Scale or Enterprise. Ideally we'd validate `data_tiering_enabled = true` against the project plan via a `ConfigValidator` and fail fast at `terraform plan` time — but the `Service` GraphQL response doesn't expose the project plan tier, so we can't validate without an extra `products` query at every plan. We rely on the API rejection at apply time (`Diagnostics.AddError` from the toggle call) instead. Open to suggestions if a cleaner validation path exists.

## Test plan

- [x] `gofmt -l` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make generate` regenerates `docs/resources/service.md` (and `docs/index.md` from the updated template) with the new attribute documented
- [x] `go test -run "^Z__no_match$" ./internal/provider/...` (test compile-check) passes
- [ ] `make testacc` — requires `TF_ACC=1` + a Scale-tier project; not run locally, will rely on CI

## Acceptance test note

The two new acceptance test steps (`WithDataTiering(true)` then `WithDataTiering(false)`) require the test project's plan to be **Scale or Enterprise**. On Free or Performance plans the API will reject the enable step. If the CI test project isn't on a tiering-capable plan, please let me know — I can guard the test behind an env var or skip it on that plan.
