### PR TITLE
fix: state upgrader for peer_cidr_blocks to recover legacy state (#309)

### DIFF
--- a/internal/provider/peering_conn_resource.go
+++ b/internal/provider/peering_conn_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -12,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -27,8 +30,9 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource              = &peeringConnectionResource{}
-	_ resource.ResourceWithConfigure = &peeringConnectionResource{}
+	_ resource.Resource                 = &peeringConnectionResource{}
+	_ resource.ResourceWithConfigure    = &peeringConnectionResource{}
+	_ resource.ResourceWithUpgradeState = &peeringConnectionResource{}
 
 	ErrPeeringConnRead         = "Error reading Peering Connection"
 	ErrPeeringConnCreate       = "Error creating Peering Connection"
@@ -395,6 +399,100 @@ func (r *peeringConnectionResource) Configure(ctx context.Context, req resource.
 	r.client = client
 }
 
+// UpgradeState migrates state written by older versions of this provider.
+//
+// v0 → v1: state for peer_cidr_blocks was sometimes written without a
+// recoverable list element type, decoding as List[DynamicPseudoType] under the
+// current framework and producing "Value Conversion Error" on plan. We rebuild
+// the model by reading raw JSON and re-emitting each attribute with explicit
+// types. See issue #309.
+func (r *peeringConnectionResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			StateUpgrader: upgradePeeringConnectionV0ToV1,
+		},
+	}
+}
+
+func upgradePeeringConnectionV0ToV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	if req.RawState == nil {
+		return
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(req.RawState.JSON, &raw); err != nil {
+		resp.Diagnostics.AddError("Unable to parse prior state JSON", err.Error())
+		return
+	}
+
+	peerCIDRBlocks, listDiags := upgradeStringList(raw["peer_cidr_blocks"])
+	resp.Diagnostics.Append(listDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	model := peeringConnectionResourceModel{
+		ID:                    upgradeInt64(raw["id"]),
+		VpcID:                 upgradeString(raw["vpc_id"]),
+		ProvisionedID:         upgradeString(raw["provisioned_id"]),
+		AccepterProvisionedID: upgradeString(raw["accepter_provisioned_id"]),
+		Status:                upgradeString(raw["status"]),
+		ErrorMessage:          upgradeString(raw["error_message"]),
+		PeerVPCID:             upgradeString(raw["peer_vpc_id"]),
+		PeerTGWID:             upgradeString(raw["peer_tgw_id"]),
+		PeerCIDRBlocks:        peerCIDRBlocks,
+		PeerCIDR:              upgradeString(raw["peer_cidr"]),
+		PeerAccountID:         upgradeString(raw["peer_account_id"]),
+		PeerRegionCode:        upgradeString(raw["peer_region_code"]),
+		TimescaleVPCID:        upgradeInt64(raw["timescale_vpc_id"]),
+		PeeringType:           upgradeString(raw["peering_type"]),
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func upgradeString(v any) types.String {
+	s, ok := v.(string)
+	if !ok {
+		return types.StringNull()
+	}
+	return types.StringValue(s)
+}
+
+func upgradeInt64(v any) types.Int64 {
+	switch x := v.(type) {
+	case float64:
+		return types.Int64Value(int64(x))
+	case json.Number:
+		n, err := x.Int64()
+		if err != nil {
+			return types.Int64Null()
+		}
+		return types.Int64Value(n)
+	}
+	return types.Int64Null()
+}
+
+func upgradeStringList(v any) (types.List, diag.Diagnostics) {
+	arr, ok := v.([]any)
+	if !ok {
+		return types.ListNull(types.StringType), nil
+	}
+	elements := make([]attr.Value, 0, len(arr))
+	for _, item := range arr {
+		if item == nil {
+			elements = append(elements, types.StringNull())
+			continue
+		}
+		s, ok := item.(string)
+		if !ok {
+			continue
+		}
+		elements = append(elements, types.StringValue(s))
+	}
+	return types.ListValue(types.StringType, elements)
+}
+
 func (r *peeringConnectionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idParts := strings.Split(req.ID, ",")
 
@@ -424,6 +522,7 @@ func (r *peeringConnectionResource) ImportState(ctx context.Context, req resourc
 
 func (r *peeringConnectionResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version:     1,
 		Description: "Schema for a peering connection (VPC or Transit Gateway). Import can be done with `peering_connection_id,timescale_vpc_id` format. Both internal IDs can be retrieved using the timescale_vpcs datasource.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{

--- a/internal/provider/peering_conn_resource_unit_test.go
+++ b/internal/provider/peering_conn_resource_unit_test.go
@@ -1,0 +1,155 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeString(t *testing.T) {
+	require.True(t, upgradeString(nil).IsNull())
+	require.True(t, upgradeString(123).IsNull(), "non-string input must yield null")
+	got := upgradeString("hello")
+	require.False(t, got.IsNull())
+	require.Equal(t, "hello", got.ValueString())
+}
+
+func TestUpgradeInt64(t *testing.T) {
+	require.True(t, upgradeInt64(nil).IsNull())
+	require.True(t, upgradeInt64("not-a-number").IsNull())
+	require.Equal(t, int64(42), upgradeInt64(float64(42)).ValueInt64())
+}
+
+func TestUpgradeStringList(t *testing.T) {
+	// nil → typed null list
+	got, diags := upgradeStringList(nil)
+	require.False(t, diags.HasError())
+	require.True(t, got.IsNull())
+	require.Equal(t, types.StringType, got.ElementType(context.Background()))
+
+	// empty array → empty typed list (not null)
+	got, diags = upgradeStringList([]any{})
+	require.False(t, diags.HasError())
+	require.False(t, got.IsNull())
+	require.Equal(t, 0, len(got.Elements()))
+	require.Equal(t, types.StringType, got.ElementType(context.Background()))
+
+	// populated array → typed list with values
+	got, diags = upgradeStringList([]any{"10.0.0.0/24", "10.0.1.0/24"})
+	require.False(t, diags.HasError())
+	require.False(t, got.IsNull())
+	require.Equal(t, 2, len(got.Elements()))
+	require.Equal(t, types.StringType, got.ElementType(context.Background()))
+
+	// non-array value → typed null list (defensive)
+	got, diags = upgradeStringList("not-a-list")
+	require.False(t, diags.HasError())
+	require.True(t, got.IsNull())
+}
+
+// TestPeeringConnectionUpgradeStateV0ToV1 exercises the full upgrader against
+// raw v0 state JSON. It covers three cases that matter for issue #309:
+//   - peer_cidr_blocks absent (state from before 2.1.0)
+//   - peer_cidr_blocks null
+//   - peer_cidr_blocks populated
+func TestPeeringConnectionUpgradeStateV0ToV1(t *testing.T) {
+	ctx := context.Background()
+	r := &peeringConnectionResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	require.False(t, schemaResp.Diagnostics.HasError())
+	require.Equal(t, int64(1), schemaResp.Schema.GetVersion(), "schema version should be 1")
+
+	upgraders := r.UpgradeState(ctx)
+	v0, ok := upgraders[0]
+	require.True(t, ok, "v0→v1 upgrader must be registered")
+
+	cases := []struct {
+		name             string
+		json             string
+		wantCIDRBlocksIs func(t *testing.T, l types.List)
+		wantPeerVPCID    string
+		wantTimescaleID  int64
+	}{
+		{
+			name: "field absent (pre-2.1.0 state)",
+			json: `{
+				"id": 42,
+				"timescale_vpc_id": 7,
+				"peer_vpc_id": "vpc-aaa",
+				"peer_account_id": "111111111111",
+				"peer_region_code": "us-east-1",
+				"peer_cidr": "10.0.0.0/24",
+				"provisioned_id": "pcx-aaa",
+				"status": "ACTIVE"
+			}`,
+			wantCIDRBlocksIs: func(t *testing.T, l types.List) {
+				require.True(t, l.IsNull(), "missing field must produce typed null list")
+				require.Equal(t, types.StringType, l.ElementType(context.Background()))
+			},
+			wantPeerVPCID:   "vpc-aaa",
+			wantTimescaleID: 7,
+		},
+		{
+			name: "explicit null",
+			json: `{
+				"id": 1,
+				"timescale_vpc_id": 2,
+				"peer_vpc_id": "vpc-bbb",
+				"peer_account_id": "222222222222",
+				"peer_region_code": "us-east-1",
+				"peer_cidr_blocks": null
+			}`,
+			wantCIDRBlocksIs: func(t *testing.T, l types.List) {
+				require.True(t, l.IsNull())
+				require.Equal(t, types.StringType, l.ElementType(context.Background()))
+			},
+			wantPeerVPCID:   "vpc-bbb",
+			wantTimescaleID: 2,
+		},
+		{
+			name: "populated",
+			json: `{
+				"id": 9,
+				"timescale_vpc_id": 3,
+				"peer_vpc_id": "vpc-ccc",
+				"peer_account_id": "333333333333",
+				"peer_region_code": "us-west-2",
+				"peer_cidr_blocks": ["10.0.0.0/24", "10.0.1.0/24"]
+			}`,
+			wantCIDRBlocksIs: func(t *testing.T, l types.List) {
+				require.False(t, l.IsNull())
+				require.Equal(t, 2, len(l.Elements()))
+				require.Equal(t, types.StringType, l.ElementType(context.Background()))
+			},
+			wantPeerVPCID:   "vpc-ccc",
+			wantTimescaleID: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := resource.UpgradeStateRequest{
+				RawState: &tfprotov6.RawState{JSON: []byte(tc.json)},
+			}
+			resp := &resource.UpgradeStateResponse{
+				State: tfsdk.State{Schema: schemaResp.Schema},
+			}
+			v0.StateUpgrader(ctx, req, resp)
+			require.False(t, resp.Diagnostics.HasError(), "diags: %v", resp.Diagnostics)
+
+			var got peeringConnectionResourceModel
+			diags := resp.State.Get(ctx, &got)
+			require.False(t, diags.HasError(), "diags: %v", diags)
+
+			tc.wantCIDRBlocksIs(t, got.PeerCIDRBlocks)
+			require.Equal(t, tc.wantPeerVPCID, got.PeerVPCID.ValueString())
+			require.Equal(t, tc.wantTimescaleID, got.TimescaleVPCID.ValueInt64())
+		})
+	}
+}


### PR DESCRIPTION
Adds a v0→v1 state upgrader for `timescale_peering_connection` to recover state written by older provider versions where `peer_cidr_blocks` could decode as `List[DynamicPseudoType]` and fail plan with a "Value Conversion Error".

The upgrader reads raw state JSON and re-emits each attribute with explicit framework types.

**Issues**

closes https://github.com/timescale/terraform-provider-timescale/issues/309

**Checklist**
- [x] Well formatted git commit message (see [these guidelines](https://chris.beams.io/posts/git-commit/))
- [x] Acceptance test coverage of new code
- [x] Run `make` locally to generate docs and add them to this PR
