### PR TITLE
fix: extend milli_cpu and memory_gb validation to support larger instance sizes

### DIFF
--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -52,8 +52,8 @@ const (
 )
 
 var (
-	memorySizes   = []int64{2, 4, 8, 16, 32, 64, 128}
-	milliCPUSizes = []int64{500, 1000, 2000, 4000, 8000, 16000, 32000}
+	memorySizes   = []int64{2, 4, 8, 16, 32, 64, 128, 192, 256}
+	milliCPUSizes = []int64{500, 1000, 2000, 4000, 8000, 16000, 32000, 48000, 64000}
 )
 
 func NewServiceResource() resource.Resource {


### PR DESCRIPTION
## Summary

Adds 48000 and 64000 to allowed `milli_cpu` values and 192 and 256 to allowed `memory_gb` values so the provider can manage services provisioned at the larger tiers (48 vCPU / 192 GB and 64 vCPU / 256 GB) the Tiger Cloud API already supports.

Cherry-picked from #346 so acceptance tests can run with secrets — fork PRs don't get them.

Closes #345.
Supersedes #346 (original author: @ingledl, preserved as commit author).

Co-authored-by: Daniel Ingle <daniel.ingle@nov.com>