### PR TITLE
feat: add data_tiering_enabled attribute to timescale_service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.13.0 (May 8, 2026)
+
+FEATURES:
+- Add `data_tiering_enabled` attribute to the `timescale_service` resource to enable [low-cost object storage tiering](https://www.tigerdata.com/docs/learn/data-lifecycle/storage/about-storage-tiers) (Scale and Enterprise plans).
+
+
 ## 2.10.0 (April 2, 2026)
 
 - Add support for read replica sets nodes.

--- a/docs/data-sources/products.md
+++ b/docs/data-sources/products.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/docs/data-sources/vpcs.md
+++ b/docs/data-sources/vpcs.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }
@@ -143,7 +143,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/docs/resources/connector_s3.md
+++ b/docs/resources/connector_s3.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/docs/resources/connector_src_postgres.md
+++ b/docs/resources/connector_src_postgres.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/docs/resources/log_exporter.md
+++ b/docs/resources/log_exporter.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/docs/resources/metric_exporter.md
+++ b/docs/resources/metric_exporter.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/docs/resources/peering_connection.md
+++ b/docs/resources/peering_connection.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -28,7 +28,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -98,7 +98,7 @@ resource "timescale_service" "secure" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `connection_pooler_enabled` (Boolean) Set connection pooler status for this service.
-- `data_tiering_enabled` (Boolean) Enable [data tiering](https://docs.timescale.com/use-timescale/latest/data-tiering/) (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only. When set to `true`, the OSM functions (`add_tiering_policy`, `tier_chunk`, `remove_tiering_policy`) become available on the service.
+- `data_tiering_enabled` (Boolean) Enable [data tiering](https://www.tigerdata.com/docs/learn/data-lifecycle/storage/about-storage-tiers) (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only. When set to `true`, the OSM functions (`add_tiering_policy`, `tier_chunk`, `remove_tiering_policy`) become available on the service. **Cannot be disabled via Terraform** — to disable, contact Tiger Data support.
 - `enable_ha_replica` (Boolean, Deprecated) Enable HA Replica (deprecated - use ha_replicas and sync_replicas instead)
 - `environment_tag` (String) Set environment tag for this service.
 - `ha_replicas` (Number) Number of HA replicas (0, 1 or 2). Modes: 1 for 'High availability'; 2 'Highest availability'. Async replicas (i.e. 'High performance' mode) will be created by default if sync_replicas is not set.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -98,6 +98,7 @@ resource "timescale_service" "secure" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `connection_pooler_enabled` (Boolean) Set connection pooler status for this service.
+- `data_tiering_enabled` (Boolean) Enable [data tiering](https://docs.timescale.com/use-timescale/latest/data-tiering/) (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only. When set to `true`, the OSM functions (`add_tiering_policy`, `tier_chunk`, `remove_tiering_policy`) become available on the service.
 - `enable_ha_replica` (Boolean, Deprecated) Enable HA Replica (deprecated - use ha_replicas and sync_replicas instead)
 - `environment_tag` (String) Set environment tag for this service.
 - `ha_replicas` (Number) Number of HA replicas (0, 1 or 2). Modes: 1 for 'High availability'; 2 'Highest availability'. Async replicas (i.e. 'High performance' mode) will be created by default if sync_replicas is not set.

--- a/docs/resources/vpcs.md
+++ b/docs/resources/vpcs.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/examples/data-sources/timescale_products/data-source.tf
+++ b/examples/data-sources/timescale_products/data-source.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/examples/data-sources/timescale_vpcs/data-source.tf
+++ b/examples/data-sources/timescale_vpcs/data-source.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/examples/resources/timescale_connector_s3/resource.tf
+++ b/examples/resources/timescale_connector_s3/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/examples/resources/timescale_connector_src_postgres/resource.tf
+++ b/examples/resources/timescale_connector_src_postgres/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/examples/resources/timescale_log_exporter/resource.tf
+++ b/examples/resources/timescale_log_exporter/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/examples/resources/timescale_metric_exporter/resource.tf
+++ b/examples/resources/timescale_metric_exporter/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/examples/resources/timescale_peering_connection/resource.tf
+++ b/examples/resources/timescale_peering_connection/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/resources/timescale_service/resource.tf
+++ b/examples/resources/timescale_service/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/examples/resources/timescale_vpcs/resource.tf
+++ b/examples/resources/timescale_vpcs/resource.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -30,6 +30,8 @@ var (
 	ToggleServiceMutation string
 	//go:embed queries/toggle_connection_pooler.graphql
 	ToggleConnectionPoolerMutation string
+	//go:embed queries/toggle_data_tiering.graphql
+	ToggleDataTieringMutation string
 	//go:embed queries/set_env_tag.graphql
 	SetEnvironmentTagMutation string
 	//go:embed queries/get_all_services.graphql

--- a/internal/client/queries/create_service.graphql
+++ b/internal/client/queries/create_service.graphql
@@ -48,6 +48,9 @@ mutation CreateService($projectId: ID!, $name: String!, $type: Type!, $resourceC
             metadata {
                 environment
             }
+            dataTieringSettings {
+                enabled
+            }
             endpoints {
                 primary {
                     host

--- a/internal/client/queries/get_all_services.graphql
+++ b/internal/client/queries/get_all_services.graphql
@@ -47,6 +47,9 @@ query GetAllServices($projectId: ID!) {
         metadata {
             environment
         }
+        dataTieringSettings {
+            enabled
+        }
         endpoints {
             primary {
                 host

--- a/internal/client/queries/get_service.graphql
+++ b/internal/client/queries/get_service.graphql
@@ -50,6 +50,9 @@ query GetService($projectId: ID!, $serviceId: ID!) {
         metadata {
             environment
         }
+        dataTieringSettings {
+            enabled
+        }
         endpoints {
             primary {
                 host

--- a/internal/client/queries/toggle_data_tiering.graphql
+++ b/internal/client/queries/toggle_data_tiering.graphql
@@ -1,0 +1,7 @@
+mutation ToggleDataTiering($projectId: ID!, $serviceId: ID!, $enable: Boolean!) {
+    toggleDataTiering (data:{
+        serviceId: $serviceId,
+        projectId: $projectId,
+        enable: $enable
+    })
+}

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -12,19 +12,20 @@ import (
 )
 
 type Service struct {
-	ID            string         `json:"id"`
-	ProjectID     string         `json:"projectId"`
-	Name          string         `json:"name"`
-	Status        string         `json:"status"`
-	RegionCode    string         `json:"regionCode"`
-	Paused        bool           `json:"paused"`
-	ServiceSpec   ServiceSpec    `json:"spec"`
-	Resources     []ResourceSpec `json:"resources"`
-	Created       string         `json:"created"`
-	ReplicaStatus string         `json:"replicaStatus"`
-	VPCEndpoint   *VPCEndpoint   `json:"vpcEndpoint"`
-	ForkSpec      *ForkSpec      `json:"forkedFromId"`
-	Metadata      *Metadata      `json:"metadata"`
+	ID                  string               `json:"id"`
+	ProjectID           string               `json:"projectId"`
+	Name                string               `json:"name"`
+	Status              string               `json:"status"`
+	RegionCode          string               `json:"regionCode"`
+	Paused              bool                 `json:"paused"`
+	ServiceSpec         ServiceSpec          `json:"spec"`
+	Resources           []ResourceSpec       `json:"resources"`
+	Created             string               `json:"created"`
+	ReplicaStatus       string               `json:"replicaStatus"`
+	VPCEndpoint         *VPCEndpoint         `json:"vpcEndpoint"`
+	ForkSpec            *ForkSpec            `json:"forkedFromId"`
+	Metadata            *Metadata            `json:"metadata"`
+	DataTieringSettings *DataTieringSettings `json:"dataTieringSettings"`
 
 	// Endpoints contains the all service endpoints
 	Endpoints *ServiceEndpoints `json:"endpoints,omitempty"`
@@ -60,6 +61,12 @@ type ResourceSpec struct {
 
 type Metadata struct {
 	Environment string `json:"environment"`
+}
+
+// DataTieringSettings reflects dataTieringSettings on the Service object.
+// When tiered storage is enabled on the service (Scale/Enterprise plan), Enabled is true.
+type DataTieringSettings struct {
+	Enabled bool `json:"enabled"`
 }
 
 type CreateServiceRequest struct {
@@ -395,6 +402,30 @@ func (c *Client) ToggleConnectionPooler(ctx context.Context, serviceID string, e
 	req := map[string]interface{}{
 		"operationName": "ToggleConnectionPooler",
 		"query":         ToggleConnectionPoolerMutation,
+		"variables": map[string]any{
+			"projectId": c.projectID,
+			"serviceId": serviceID,
+			"enable":    enable,
+		},
+	}
+	var resp Response[any]
+	if err := c.do(ctx, req, &resp); err != nil {
+		return err
+	}
+	if len(resp.Errors) > 0 {
+		return resp.Errors[0]
+	}
+	if resp.Data == nil {
+		return errors.New("no response found")
+	}
+	return nil
+}
+
+func (c *Client) ToggleDataTiering(ctx context.Context, serviceID string, enable bool) error {
+	tflog.Trace(ctx, "Client.ToggleDataTiering")
+	req := map[string]interface{}{
+		"operationName": "ToggleDataTiering",
+		"query":         ToggleDataTieringMutation,
 		"variables": map[string]any{
 			"projectId": c.projectID,
 			"serviceId": serviceID,

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -92,6 +92,7 @@ type serviceResourceModel struct {
 	ReadReplicaNodes        types.Int64    `tfsdk:"read_replica_nodes"`
 	VpcID                   types.Int64    `tfsdk:"vpc_id"`
 	ConnectionPoolerEnabled types.Bool     `tfsdk:"connection_pooler_enabled"`
+	DataTieringEnabled      types.Bool     `tfsdk:"data_tiering_enabled"`
 	EnvironmentTag          types.String   `tfsdk:"environment_tag"`
 	MetricExporterID        types.String   `tfsdk:"metric_exporter_id"`
 	LogExporterID           types.String   `tfsdk:"log_exporter_id"`
@@ -289,6 +290,16 @@ The change has been taken into account but must still be propagated. You can run
 			"connection_pooler_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Set connection pooler status for this service.",
 				Description:         "Set connection pooler status for this service.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"data_tiering_enabled": schema.BoolAttribute{
+				MarkdownDescription: "Enable [data tiering](https://docs.timescale.com/use-timescale/latest/data-tiering/) (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only. When set to `true`, the OSM functions (`add_tiering_policy`, `tier_chunk`, `remove_tiering_policy`) become available on the service.",
+				Description:         "Enable data tiering (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only.",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
@@ -570,6 +581,21 @@ func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 	}
 
+	// Data tiering — services are created with tiering disabled. If the plan asks
+	// for it enabled, toggle it on and refresh state. Toggling false on a freshly
+	// created service is a no-op so we skip the call when not requested.
+	if plan.DataTieringEnabled.ValueBool() {
+		if err := r.client.ToggleDataTiering(ctx, service.ID, true); err != nil {
+			resp.Diagnostics.AddError("Failed to enable data tiering", err.Error())
+			return
+		}
+		service, err = r.client.GetService(ctx, service.ID)
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to enable data tiering", "unable to refresh service after enabling data tiering")
+			return
+		}
+	}
+
 	resourceModel := serviceToResource(resp.Diagnostics, service, plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, resourceModel)...)
 	if resp.Diagnostics.HasError() {
@@ -736,6 +762,13 @@ func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest
 	if plan.ConnectionPoolerEnabled != state.ConnectionPoolerEnabled {
 		if err := r.client.ToggleConnectionPooler(ctx, serviceID, plan.ConnectionPoolerEnabled.ValueBool()); err != nil {
 			resp.Diagnostics.AddError("Failed to toggle connection pooler", err.Error())
+			return
+		}
+	}
+	// Data tiering /////////////////////////////////////////////
+	if plan.DataTieringEnabled != state.DataTieringEnabled {
+		if err := r.client.ToggleDataTiering(ctx, serviceID, plan.DataTieringEnabled.ValueBool()); err != nil {
+			resp.Diagnostics.AddError("Failed to toggle data tiering", err.Error())
 			return
 		}
 	}
@@ -943,6 +976,7 @@ func (r *serviceResource) ImportState(ctx context.Context, req resource.ImportSt
 
 func serviceToResource(diag diag.Diagnostics, s *tsClient.Service, state serviceResourceModel) serviceResourceModel {
 	hasPooler := s.ServiceSpec.PoolerEnabled
+	hasDataTiering := s.DataTieringSettings != nil && s.DataTieringSettings.Enabled
 	replicaCount := s.Resources[0].Spec.ReplicaCount
 	syncReplicaCount := s.Resources[0].Spec.SyncReplicaCount
 
@@ -977,6 +1011,7 @@ func serviceToResource(diag diag.Diagnostics, s *tsClient.Service, state service
 		ReadReplicaSource:       state.ReadReplicaSource,
 		ReadReplicaNodes:        readReplicaNodes,
 		ConnectionPoolerEnabled: types.BoolValue(hasPooler),
+		DataTieringEnabled:      types.BoolValue(hasDataTiering),
 		EnableHAReplica:         types.BoolNull(),
 		Hostname:                types.StringNull(),
 		Port:                    types.Int64Null(),

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -298,11 +298,10 @@ The change has been taken into account but must still be propagated. You can run
 				},
 			},
 			"data_tiering_enabled": schema.BoolAttribute{
-				MarkdownDescription: "Enable [data tiering](https://docs.timescale.com/use-timescale/latest/data-tiering/) (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only. When set to `true`, the OSM functions (`add_tiering_policy`, `tier_chunk`, `remove_tiering_policy`) become available on the service.",
-				Description:         "Enable data tiering (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only.",
+				MarkdownDescription: "Enable [data tiering](https://www.tigerdata.com/docs/learn/data-lifecycle/storage/about-storage-tiers) (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only. When set to `true`, the OSM functions (`add_tiering_policy`, `tier_chunk`, `remove_tiering_policy`) become available on the service. **Cannot be disabled via Terraform** — to disable, contact Tiger Data support.",
+				Description:         "Enable data tiering (low-cost object storage tier on Tiger-managed S3) for this service. Available on Scale and Enterprise plans only. Cannot be disabled via Terraform.",
 				Optional:            true,
 				Computed:            true,
-				Default:             booldefault.StaticBool(false),
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
@@ -766,7 +765,17 @@ func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest
 		}
 	}
 	// Data tiering /////////////////////////////////////////////
+	// Disabling tiering is not supported via the Tiger Cloud API (no UI button
+	// for it either) — match that constraint here so the user gets a clear error
+	// instead of an opaque API failure.
 	if plan.DataTieringEnabled != state.DataTieringEnabled {
+		if state.DataTieringEnabled.ValueBool() && !plan.DataTieringEnabled.ValueBool() {
+			resp.Diagnostics.AddError(
+				"Cannot disable data tiering via Terraform",
+				"Disabling data tiering is not supported through the Tiger Cloud API. Contact Tiger Data support if you need to disable it.",
+			)
+			return
+		}
 		if err := r.client.ToggleDataTiering(ctx, serviceID, plan.DataTieringEnabled.ValueBool()); err != nil {
 			resp.Diagnostics.AddError("Failed to toggle data tiering", err.Error())
 			return

--- a/internal/provider/service_resource_test.go
+++ b/internal/provider/service_resource_test.go
@@ -78,18 +78,12 @@ func TestServiceResource_Default_Success(t *testing.T) {
 					resource.TestCheckResourceAttrSet("timescale_service.resource", "pooler_port"),
 				),
 			},
-			// Enable data tiering (requires Scale or Enterprise plan on the test project)
+			// Enable data tiering (requires Scale or Enterprise plan on the test project).
+			// Disabling is intentionally not tested: the API does not support it
 			{
 				Config: getServiceConfig(t, config.WithDataTiering(true)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("timescale_service.resource", "data_tiering_enabled", "true"),
-				),
-			},
-			// Disable data tiering
-			{
-				Config: getServiceConfig(t, config.WithDataTiering(false)),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("timescale_service.resource", "data_tiering_enabled", "false"),
 				),
 			},
 			// Enable HA replica (deprecated but still maintained for backwards compatibility)

--- a/internal/provider/service_resource_test.go
+++ b/internal/provider/service_resource_test.go
@@ -42,6 +42,7 @@ func TestServiceResource_Default_Success(t *testing.T) {
 					resource.TestCheckResourceAttr("timescale_service.resource", "ha_replicas", "0"),
 					resource.TestCheckResourceAttr("timescale_service.resource", "sync_replicas", "0"),
 					resource.TestCheckResourceAttr("timescale_service.resource", "connection_pooler_enabled", "false"),
+					resource.TestCheckResourceAttr("timescale_service.resource", "data_tiering_enabled", "false"),
 					resource.TestCheckResourceAttr("timescale_service.resource", "environment_tag", "DEV"),
 					resource.TestCheckNoResourceAttr("timescale_service.resource", "vpc_id"),
 				),
@@ -75,6 +76,20 @@ func TestServiceResource_Default_Success(t *testing.T) {
 					resource.TestCheckResourceAttr("timescale_service.resource", "connection_pooler_enabled", "true"),
 					resource.TestCheckResourceAttrSet("timescale_service.resource", "pooler_hostname"),
 					resource.TestCheckResourceAttrSet("timescale_service.resource", "pooler_port"),
+				),
+			},
+			// Enable data tiering (requires Scale or Enterprise plan on the test project)
+			{
+				Config: getServiceConfig(t, config.WithDataTiering(true)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("timescale_service.resource", "data_tiering_enabled", "true"),
+				),
+			},
+			// Disable data tiering
+			{
+				Config: getServiceConfig(t, config.WithDataTiering(false)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("timescale_service.resource", "data_tiering_enabled", "false"),
 				),
 			},
 			// Enable HA replica (deprecated but still maintained for backwards compatibility)
@@ -567,6 +582,7 @@ type ServiceConfig struct {
 	ReadReplicaSource string
 	ReadReplicaNodes  *int64
 	Pooler            bool
+	DataTiering       bool
 	Environment       string
 	Password          string
 	PasswordWo        string
@@ -635,6 +651,11 @@ func (c *ServiceConfig) WithPooler(pooler bool) *ServiceConfig {
 	return c
 }
 
+func (c *ServiceConfig) WithDataTiering(enabled bool) *ServiceConfig {
+	c.DataTiering = enabled
+	return c
+}
+
 func (c *ServiceConfig) WithReadReplica(source string) *ServiceConfig {
 	c.ReadReplicaSource = source
 	return c
@@ -680,6 +701,9 @@ func (c *ServiceConfig) String(t *testing.T) string {
 	}
 	if c.Pooler {
 		write("connection_pooler_enabled = %t \n", c.Pooler)
+	}
+	if c.DataTiering {
+		write("data_tiering_enabled = %t \n", c.DataTiering)
 	}
 	if c.Environment != "" {
 		write("environment_tag = %q \n", c.Environment)

--- a/templates/index.md
+++ b/templates/index.md
@@ -39,7 +39,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }
@@ -143,7 +143,7 @@ terraform {
   required_providers {
     timescale = {
       source  = "timescale/timescale"
-      version = "~> 2.11"
+      version = "~> 2.13"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a new `data_tiering_enabled` attribute on the `timescale_service` resource. Mirrors `connection_pooler_enabled` end-to-end — new GraphQL `toggleDataTiering` mutation, new field on the `Service` struct sourced from `dataTieringSettings { enabled }` on every service query, conditional toggle in `Create()` (only when `true`, since services are created with tiering disabled), and conditional toggle in `Update()`.

Cherry-picked from #347 (original author: @johanferguth, preserved as commit author) so acceptance tests can run with secrets — fork PRs don't get them.

Closes #239.
Supersedes #347.

## What's in this PR

1. **`feat: add data_tiering_enabled attribute…`** — @johanferguth's original implementation.
2. **`Update changelog and examples versions`** — CHANGELOG entry for 2.13.0 + bump every `~> 2.11` reference in examples/templates/docs to `~> 2.13`.
3. **`fix: make data_tiering_enabled enable-only to match Tiger Cloud API`** — adjustments after review (see below).

## Behavior changes vs the original PR

The Tiger Cloud console doesn't expose a "disable tiered storage" button. To match that constraint:

- **Removed `Default: booldefault.StaticBool(false)`** on the schema. With the default in place, omitting the attribute from config defaulted it to `false`, which would silently try to disable a service that had tiering enabled. With only `Optional + Computed + UseStateForUnknown`, omitting the attribute means "leave it alone."
- **Reject `true → false` transitions in `Update()`** with a clear error pointing at support. Disabling is not supported via the API; we surface a friendly error instead of an opaque API failure.
- **Dropped the disable step from the acceptance test** — added a comment explaining why.
- Schema description updated to spell out the constraint.

Read path is unchanged from the original PR: trusts the API response (`s.DataTieringSettings != nil && s.DataTieringSettings.Enabled`), handles `nil` for backward compatibility.

Co-authored-by: @johanferguth