### PR TITLE
fix: gracefully handle out-of-band service deletion (#288)

### DIFF
--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -305,6 +305,11 @@ func (c *Client) ResizeInstance(ctx context.Context, serviceID string, config Re
 	return nil
 }
 
+// ErrServiceNotFound is returned when the API reports that the requested
+// service does not exist. Callers can use errors.Is to detect this case and
+// drop the resource from terraform state instead of erroring on the read.
+var ErrServiceNotFound = errors.New("no service with that id exists")
+
 func (c *Client) GetService(ctx context.Context, id string) (*Service, error) {
 	tflog.Trace(ctx, "Client.GetService")
 	req := map[string]interface{}{
@@ -320,6 +325,9 @@ func (c *Client) GetService(ctx context.Context, id string) (*Service, error) {
 		return nil, err
 	}
 	if len(resp.Errors) > 0 {
+		if resp.Errors[0].Message == ErrServiceNotFound.Error() {
+			return nil, ErrServiceNotFound
+		}
 		return nil, resp.Errors[0]
 	}
 	if resp.Data == nil {
@@ -389,6 +397,9 @@ func (c *Client) DeleteService(ctx context.Context, id string) (*Service, error)
 		return nil, err
 	}
 	if len(resp.Errors) > 0 {
+		if resp.Errors[0].Message == ErrServiceNotFound.Error() {
+			return nil, ErrServiceNotFound
+		}
 		return nil, resp.Errors[0]
 	}
 	if resp.Data == nil {

--- a/internal/client/service_test.go
+++ b/internal/client/service_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockGraphQLServer returns an httptest server that responds with the supplied
+// GraphQL response body for any POST. The Client points its base URL here via
+// TIMESCALE_DEV_URL during the test.
+func mockGraphQLServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, body)
+	}))
+}
+
+// newTestClient builds a Client pointing at the given mock-server URL. We use
+// the unexported `url` field directly because this is a white-box test in the
+// same package, which keeps the production NewClient API focused.
+func newTestClient(url string) *Client {
+	c := NewClient("token", "proj", "test", "1.0.0")
+	c.url = url
+	return c
+}
+
+func TestGetService_NotFoundReturnsSentinel(t *testing.T) {
+	srv := mockGraphQLServer(t, `{"errors":[{"message":"no service with that id exists"}]}`)
+	defer srv.Close()
+
+	_, err := newTestClient(srv.URL).GetService(context.Background(), "any-id")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrServiceNotFound), "expected ErrServiceNotFound, got %v", err)
+}
+
+func TestGetService_OtherErrorPassthrough(t *testing.T) {
+	srv := mockGraphQLServer(t, `{"errors":[{"message":"some other API error"}]}`)
+	defer srv.Close()
+
+	_, err := newTestClient(srv.URL).GetService(context.Background(), "any-id")
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrServiceNotFound), "non-not-found errors must not match the sentinel")
+	require.Contains(t, err.Error(), "some other API error")
+}
+
+func TestDeleteService_NotFoundReturnsSentinel(t *testing.T) {
+	srv := mockGraphQLServer(t, `{"errors":[{"message":"no service with that id exists"}]}`)
+	defer srv.Close()
+
+	_, err := newTestClient(srv.URL).DeleteService(context.Background(), "any-id")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrServiceNotFound), "expected ErrServiceNotFound, got %v", err)
+}

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -700,6 +700,14 @@ func (r *serviceResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	service, err := r.client.GetService(ctx, state.ID.ValueString())
 	if err != nil {
+		// If the service was deleted out-of-band (e.g. via the Tiger Cloud
+		// console), drop it from terraform state so the next plan recreates
+		// it cleanly instead of failing forever.
+		if errors.Is(err, tsClient.ErrServiceNotFound) {
+			tflog.Warn(ctx, "Service not found, removing from state.", map[string]any{"id": state.ID.ValueString()})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read service, got error: %s", err))
 		return
 	}
@@ -971,9 +979,15 @@ func (r *serviceResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	_, err := r.client.DeleteService(ctx, data.ID.ValueString())
 	if err != nil {
+		// Already gone (e.g. deleted out-of-band) is success — there's nothing
+		// to clean up and terraform's Delete contract is already satisfied.
+		if errors.Is(err, tsClient.ErrServiceNotFound) {
+			tflog.Warn(ctx, "Service already deleted, treating as success.", map[string]any{"id": data.ID.ValueString()})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting Timescale Service",
-			"Could not delete order, unexpected error: "+err.Error(),
+			"Could not delete service, unexpected error: "+err.Error(),
 		)
 		return
 	}


### PR DESCRIPTION
## Summary

When a customer deletes a service via the Tiger Cloud console while terraform is still managing it, the next `terraform plan` / `apply` / `destroy` fails with `Error: Unable to read service, got error: no service with that id exists`. The provider refuses to remove the orphaned state row, leaving the user stuck.

This change mirrors the existing pattern used by `ErrVPCNotFound` and the `metric_exporter_resource` Read path: detect the not-found error in the client, surface a sentinel, and let the resource drop itself from state on `Read()` (recreate on next apply) or treat it as success on `Delete()`.

## Changes

- **`internal/client/service.go`**: add exported `ErrServiceNotFound` sentinel. `GetService` and `DeleteService` map the API's `"no service with that id exists"` error message to it; other errors pass through unchanged.
- **`internal/provider/service_resource.go`**:
  - `Read()` calls `resp.State.RemoveResource(ctx)` on the sentinel instead of erroring.
  - `Delete()` treats the sentinel as success (already gone — defensive, since refresh usually catches this first via `Read`).
- **`internal/client/service_test.go`** (new): white-box unit tests using `httptest` cover positive sentinel mapping, negative pass-through, and the Delete path.

Closes #288.