### PR TITLE
fix: inconsistent state for replica/pooler endpoints after vpc_id change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.13.3 (June 17, 2026)
+
+BUG FIXES:
+- Fix "Provider produced inconsistent result after apply" errors for the `replica_hostname`, `replica_port`, `pooler_hostname`, and `pooler_port` attributes of `timescale_service` when changing `vpc_id`. Attaching or detaching a Peering VPC moves the replica and pooler endpoints too, so they are now refreshed on a `vpc_id` change instead of promising stale values.
+
+
 ## 2.13.0 (May 8, 2026)
 
 FEATURES:

--- a/internal/provider/plan_modifiers.go
+++ b/internal/provider/plan_modifiers.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -12,23 +13,23 @@ import (
 )
 
 // useStateUnlessToggleChangesString returns a plan modifier that preserves the
-// prior state value (like UseStateForUnknown) unless the attribute at togglePath
-// has changed, in which case the value is left as unknown so the provider can
-// populate it after apply.
-func useStateUnlessToggleChangesString(togglePath string) planmodifier.String {
-	return &stringTogglePlanModifier{togglePath: togglePath}
+// prior state value (like UseStateForUnknown) unless any of the attributes at
+// togglePaths has changed, in which case the value is left as unknown so the
+// provider can populate it after apply.
+func useStateUnlessToggleChangesString(togglePaths ...string) planmodifier.String {
+	return &stringTogglePlanModifier{togglePaths: togglePaths}
 }
 
-func useStateUnlessToggleChangesInt64(togglePath string) planmodifier.Int64 {
-	return &int64TogglePlanModifier{togglePath: togglePath}
+func useStateUnlessToggleChangesInt64(togglePaths ...string) planmodifier.Int64 {
+	return &int64TogglePlanModifier{togglePaths: togglePaths}
 }
 
 type stringTogglePlanModifier struct {
-	togglePath string
+	togglePaths []string
 }
 
 func (m *stringTogglePlanModifier) Description(_ context.Context) string {
-	return "Use state value unless " + m.togglePath + " changes"
+	return "Use state value unless " + strings.Join(m.togglePaths, " or ") + " changes"
 }
 
 func (m *stringTogglePlanModifier) MarkdownDescription(ctx context.Context) string {
@@ -44,7 +45,7 @@ func (m *stringTogglePlanModifier) PlanModifyString(ctx context.Context, req pla
 		return
 	}
 
-	if toggleChanged(ctx, req.State, req.Plan, m.togglePath) {
+	if anyToggleChanged(ctx, req.State, req.Plan, m.togglePaths) {
 		resp.PlanValue = types.StringUnknown()
 		return
 	}
@@ -53,11 +54,11 @@ func (m *stringTogglePlanModifier) PlanModifyString(ctx context.Context, req pla
 }
 
 type int64TogglePlanModifier struct {
-	togglePath string
+	togglePaths []string
 }
 
 func (m *int64TogglePlanModifier) Description(_ context.Context) string {
-	return "Use state value unless " + m.togglePath + " changes"
+	return "Use state value unless " + strings.Join(m.togglePaths, " or ") + " changes"
 }
 
 func (m *int64TogglePlanModifier) MarkdownDescription(ctx context.Context) string {
@@ -73,12 +74,21 @@ func (m *int64TogglePlanModifier) PlanModifyInt64(ctx context.Context, req planm
 		return
 	}
 
-	if toggleChanged(ctx, req.State, req.Plan, m.togglePath) {
+	if anyToggleChanged(ctx, req.State, req.Plan, m.togglePaths) {
 		resp.PlanValue = types.Int64Unknown()
 		return
 	}
 
 	resp.PlanValue = req.StateValue
+}
+
+func anyToggleChanged(ctx context.Context, state tfsdk.State, plan tfsdk.Plan, togglePaths []string) bool {
+	for _, togglePath := range togglePaths {
+		if toggleChanged(ctx, state, plan, togglePath) {
+			return true
+		}
+	}
+	return false
 }
 
 func toggleChanged(ctx context.Context, state tfsdk.State, plan tfsdk.Plan, togglePath string) bool {

--- a/internal/provider/plan_modifiers_test.go
+++ b/internal/provider/plan_modifiers_test.go
@@ -166,3 +166,187 @@ func TestServiceSchema_HostnamePreservedWhenVpcUnchanged(t *testing.T) {
 		t.Errorf("hostname should be preserved when vpc_id unchanged, got %s", resp.PlanValue)
 	}
 }
+
+// TestServiceSchema_StringEndpointsRefreshOnToggleChange verifies that the
+// replica/pooler hostname attributes are left unknown when any attribute that
+// moves them changes: vpc_id moves every endpoint of the service (attaching or
+// detaching a VPC rewrites the replica and pooler DNS names too), ha_replicas
+// moves the replica endpoint, and connection_pooler_enabled moves the pooler
+// endpoint.
+func TestServiceSchema_StringEndpointsRefreshOnToggleChange(t *testing.T) {
+	s := getServiceSchema(t)
+
+	cases := []struct {
+		attr        string
+		toggle      string
+		stateToggle tftypes.Value
+		planToggle  tftypes.Value
+	}{
+		{"replica_hostname", "vpc_id", tftypes.NewValue(tftypes.Number, 100), tftypes.NewValue(tftypes.Number, 200)},
+		{"pooler_hostname", "vpc_id", tftypes.NewValue(tftypes.Number, 100), tftypes.NewValue(tftypes.Number, 200)},
+		{"replica_hostname", "ha_replicas", tftypes.NewValue(tftypes.Number, 0), tftypes.NewValue(tftypes.Number, 1)},
+		{"pooler_hostname", "connection_pooler_enabled", tftypes.NewValue(tftypes.Bool, false), tftypes.NewValue(tftypes.Bool, true)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.attr+" on "+tc.toggle, func(t *testing.T) {
+			strAttr, ok := s.Attributes[tc.attr].(schema.StringAttribute)
+			if !ok {
+				t.Fatalf("%s attribute is not a StringAttribute", tc.attr)
+			}
+
+			stateRaw := buildTFValues(t, s, map[string]tftypes.Value{
+				tc.attr:   tftypes.NewValue(tftypes.String, "old-host.example.com"),
+				tc.toggle: tc.stateToggle,
+			})
+			planRaw := buildTFValues(t, s, map[string]tftypes.Value{
+				tc.attr:   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				tc.toggle: tc.planToggle,
+			})
+
+			req := planmodifier.StringRequest{
+				PlanValue:  types.StringUnknown(),
+				StateValue: types.StringValue("old-host.example.com"),
+				State:      tfsdk.State{Schema: s, Raw: stateRaw},
+				Plan:       tfsdk.Plan{Schema: s, Raw: planRaw},
+			}
+			resp := &planmodifier.StringResponse{PlanValue: req.PlanValue}
+
+			for _, mod := range strAttr.PlanModifiers {
+				mod.PlanModifyString(context.Background(), req, resp)
+			}
+
+			if !resp.PlanValue.IsUnknown() {
+				t.Errorf("%s should be unknown when %s changes, got %q — the plan modifier is not %s-aware", tc.attr, tc.toggle, resp.PlanValue.ValueString(), tc.toggle)
+			}
+		})
+	}
+}
+
+// TestServiceSchema_Int64EndpointsRefreshOnToggleChange is the same matrix for
+// the replica/pooler port attributes.
+func TestServiceSchema_Int64EndpointsRefreshOnToggleChange(t *testing.T) {
+	s := getServiceSchema(t)
+
+	cases := []struct {
+		attr        string
+		toggle      string
+		stateToggle tftypes.Value
+		planToggle  tftypes.Value
+	}{
+		{"replica_port", "vpc_id", tftypes.NewValue(tftypes.Number, 100), tftypes.NewValue(tftypes.Number, 200)},
+		{"pooler_port", "vpc_id", tftypes.NewValue(tftypes.Number, 100), tftypes.NewValue(tftypes.Number, 200)},
+		{"replica_port", "ha_replicas", tftypes.NewValue(tftypes.Number, 0), tftypes.NewValue(tftypes.Number, 1)},
+		{"pooler_port", "connection_pooler_enabled", tftypes.NewValue(tftypes.Bool, false), tftypes.NewValue(tftypes.Bool, true)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.attr+" on "+tc.toggle, func(t *testing.T) {
+			intAttr, ok := s.Attributes[tc.attr].(schema.Int64Attribute)
+			if !ok {
+				t.Fatalf("%s attribute is not an Int64Attribute", tc.attr)
+			}
+
+			stateRaw := buildTFValues(t, s, map[string]tftypes.Value{
+				tc.attr:   tftypes.NewValue(tftypes.Number, 5432),
+				tc.toggle: tc.stateToggle,
+			})
+			planRaw := buildTFValues(t, s, map[string]tftypes.Value{
+				tc.attr:   tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+				tc.toggle: tc.planToggle,
+			})
+
+			req := planmodifier.Int64Request{
+				PlanValue:  types.Int64Unknown(),
+				StateValue: types.Int64Value(5432),
+				State:      tfsdk.State{Schema: s, Raw: stateRaw},
+				Plan:       tfsdk.Plan{Schema: s, Raw: planRaw},
+			}
+			resp := &planmodifier.Int64Response{PlanValue: req.PlanValue}
+
+			for _, mod := range intAttr.PlanModifiers {
+				mod.PlanModifyInt64(context.Background(), req, resp)
+			}
+
+			if !resp.PlanValue.IsUnknown() {
+				t.Errorf("%s should be unknown when %s changes, got %d — the plan modifier is not %s-aware", tc.attr, tc.toggle, resp.PlanValue.ValueInt64(), tc.toggle)
+			}
+		})
+	}
+}
+
+// TestServiceSchema_EndpointsPreservedWhenTogglesUnchanged verifies the
+// replica/pooler endpoints keep the state value when neither vpc_id nor their
+// feature toggle changes.
+func TestServiceSchema_EndpointsPreservedWhenTogglesUnchanged(t *testing.T) {
+	s := getServiceSchema(t)
+
+	t.Run("replica_hostname", func(t *testing.T) {
+		strAttr, ok := s.Attributes["replica_hostname"].(schema.StringAttribute)
+		if !ok {
+			t.Fatal("replica_hostname attribute is not a StringAttribute")
+		}
+
+		unchanged := map[string]tftypes.Value{
+			"replica_hostname": tftypes.NewValue(tftypes.String, "repl.example.com"),
+			"ha_replicas":      tftypes.NewValue(tftypes.Number, 1),
+			"vpc_id":           tftypes.NewValue(tftypes.Number, 100),
+		}
+		stateRaw := buildTFValues(t, s, unchanged)
+		planRaw := buildTFValues(t, s, map[string]tftypes.Value{
+			"replica_hostname": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			"ha_replicas":      tftypes.NewValue(tftypes.Number, 1),
+			"vpc_id":           tftypes.NewValue(tftypes.Number, 100),
+		})
+
+		req := planmodifier.StringRequest{
+			PlanValue:  types.StringUnknown(),
+			StateValue: types.StringValue("repl.example.com"),
+			State:      tfsdk.State{Schema: s, Raw: stateRaw},
+			Plan:       tfsdk.Plan{Schema: s, Raw: planRaw},
+		}
+		resp := &planmodifier.StringResponse{PlanValue: req.PlanValue}
+
+		for _, mod := range strAttr.PlanModifiers {
+			mod.PlanModifyString(context.Background(), req, resp)
+		}
+
+		if resp.PlanValue.ValueString() != "repl.example.com" {
+			t.Errorf("replica_hostname should be preserved when toggles are unchanged, got %s", resp.PlanValue)
+		}
+	})
+
+	t.Run("pooler_port", func(t *testing.T) {
+		intAttr, ok := s.Attributes["pooler_port"].(schema.Int64Attribute)
+		if !ok {
+			t.Fatal("pooler_port attribute is not an Int64Attribute")
+		}
+
+		stateRaw := buildTFValues(t, s, map[string]tftypes.Value{
+			"pooler_port":               tftypes.NewValue(tftypes.Number, 6432),
+			"connection_pooler_enabled": tftypes.NewValue(tftypes.Bool, true),
+			"vpc_id":                    tftypes.NewValue(tftypes.Number, 100),
+		})
+		planRaw := buildTFValues(t, s, map[string]tftypes.Value{
+			"pooler_port":               tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			"connection_pooler_enabled": tftypes.NewValue(tftypes.Bool, true),
+			"vpc_id":                    tftypes.NewValue(tftypes.Number, 100),
+		})
+
+		req := planmodifier.Int64Request{
+			PlanValue:  types.Int64Unknown(),
+			StateValue: types.Int64Value(6432),
+			State:      tfsdk.State{Schema: s, Raw: stateRaw},
+			Plan:       tfsdk.Plan{Schema: s, Raw: planRaw},
+		}
+		resp := &planmodifier.Int64Response{PlanValue: req.PlanValue}
+
+		for _, mod := range intAttr.PlanModifiers {
+			mod.PlanModifyInt64(context.Background(), req, resp)
+		}
+
+		if resp.PlanValue.ValueInt64() != 6432 {
+			t.Errorf("pooler_port should be preserved when toggles are unchanged, got %s", resp.PlanValue)
+		}
+	})
+}

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -260,7 +260,7 @@ The change has been taken into account but must still be propagated. You can run
 				Description:         "Hostname of the HA-Replica of this service.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
-					useStateUnlessToggleChangesString("ha_replicas"),
+					useStateUnlessToggleChangesString("ha_replicas", "vpc_id"),
 				},
 			},
 			"replica_port": schema.Int64Attribute{
@@ -268,7 +268,7 @@ The change has been taken into account but must still be propagated. You can run
 				Description:         "Port of the HA-Replica of this service.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.Int64{
-					useStateUnlessToggleChangesInt64("ha_replicas"),
+					useStateUnlessToggleChangesInt64("ha_replicas", "vpc_id"),
 				},
 			},
 			"pooler_hostname": schema.StringAttribute{
@@ -276,7 +276,7 @@ The change has been taken into account but must still be propagated. You can run
 				Description:         "Hostname of the pooler of this service.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
-					useStateUnlessToggleChangesString("connection_pooler_enabled"),
+					useStateUnlessToggleChangesString("connection_pooler_enabled", "vpc_id"),
 				},
 			},
 			"pooler_port": schema.Int64Attribute{
@@ -284,7 +284,7 @@ The change has been taken into account but must still be propagated. You can run
 				Description:         "Port of the pooler of this service.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.Int64{
-					useStateUnlessToggleChangesInt64("connection_pooler_enabled"),
+					useStateUnlessToggleChangesInt64("connection_pooler_enabled", "vpc_id"),
 				},
 			},
 			"connection_pooler_enabled": schema.BoolAttribute{


### PR DESCRIPTION
> **Supersedes #366** by @AprilNEA. We can't merge fork PRs directly because the acceptance-test CI relies on repository secrets that GitHub does not expose to fork-triggered workflows, so #366's tests can't run there. This PR cherry-picks @AprilNEA's commit verbatim (authorship preserved) so the secret-backed CI runs — all credit for the fix goes to them. It also adds a `2.13.3` CHANGELOG entry. #366 should be closed in favor of this one.

## Bug

Changing `vpc_id` on a `timescale_service` (attaching it to / detaching it from a Peering VPC) also moves the **replica** and **pooler** endpoints, but their plan modifiers only watch `ha_replicas` / `connection_pooler_enabled`. The plan therefore promises the old values and the apply returns new ones:

```
Error: Provider produced inconsistent result after apply

When applying changes to timescale_service.this, provider
"provider[\"registry.opentofu.org/timescale/timescale\"]" produced an
unexpected new value: .replica_hostname: was
cty.StringVal("xxxxxxxxxx-repl.yyyyyyyyyy.tsdb.cloud.timescale.com"), but now
cty.StringVal("xxxxxxxxxx-repl.yyyyyyyyyy.vpc.tsdb.forge.timescale.com").
```

…×4, for `replica_hostname`, `replica_port`, `pooler_hostname`, and `pooler_port` (the pooler/replica ports also change, e.g. 35258 → 5432). Observed on v2.13.2 while attaching a live service with `ha_replicas = 1` and `connection_pooler_enabled = true` to a VPC. The attach itself succeeds and state settles on the next refresh, but every `vpc_id` change on such a service errors.

## Repro

```hcl
resource "timescale_service" "this" {
  name                      = "repro"
  milli_cpu                 = 2000
  memory_gb                 = 8
  region_code               = "us-west-2"
  connection_pooler_enabled = true
  ha_replicas               = 1
  vpc_id                    = timescale_vpcs.this.id # add or remove this line, then apply
}
```

## Fix

Follow-up to #325, which fixed `hostname`/`port` for the same root cause. The toggle plan modifiers now accept multiple watched attributes, and the four endpoint attributes additionally watch `vpc_id`:

```go
useStateUnlessToggleChangesString("ha_replicas", "vpc_id")               // replica_hostname
useStateUnlessToggleChangesInt64("ha_replicas", "vpc_id")                // replica_port
useStateUnlessToggleChangesString("connection_pooler_enabled", "vpc_id") // pooler_hostname
useStateUnlessToggleChangesInt64("connection_pooler_enabled", "vpc_id")  // pooler_port
```

Single-argument call sites are unchanged (`hostname`/`port` keep watching only `vpc_id`).

## Tests

`plan_modifiers_test.go` gains a matrix over the four endpoint attributes, in the style of the #325 tests:

- left unknown when `vpc_id` changes — these four sub-tests fail without the schema change in this PR;
- still left unknown when their own feature toggle (`ha_replicas` / `connection_pooler_enabled`) changes;
- preserved from state when nothing relevant changes.

`gofmt` is clean; `go build ./...` and `go test ./...` pass.