### PR TITLE
docs: add troubleshooting note for PROJECT_PERMISSION_READ on VPC reads

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -235,6 +235,16 @@ Please reference the [docs](https://docs.tigerdata.com/use-timescale/latest/regi
 ✅ Log exporters <br />
 ✅ S3 connector <br />
 
+## Troubleshooting
+
+### `missing project permission: PROJECT_PERMISSION_READ for project ...`
+
+Provider versions **< 2.4.0** did not scope the VPC lookup by project, so reading a
+`timescale_vpcs` or `timescale_peering_connection` resource could fail this permission
+check when the credentials' default project differs from the project the VPC belongs to.
+This was fixed in **v2.4.0** ([#274](https://github.com/timescale/terraform-provider-timescale/pull/274)).
+If you hit this error, upgrade to any provider version ≥ 2.4.0.
+
 ## Billing
 Services are currently billed for hourly usage. If a service is running for less than an hour,
 it will still be charged for the full hour of usage.

--- a/templates/index.md
+++ b/templates/index.md
@@ -235,6 +235,16 @@ Please reference the [docs](https://docs.tigerdata.com/use-timescale/latest/regi
 ✅ Log exporters <br />
 ✅ S3 connector <br />
 
+## Troubleshooting
+
+### `missing project permission: PROJECT_PERMISSION_READ for project ...`
+
+Provider versions **< 2.4.0** did not scope the VPC lookup by project, so reading a
+`timescale_vpcs` or `timescale_peering_connection` resource could fail this permission
+check when the credentials' default project differs from the project the VPC belongs to.
+This was fixed in **v2.4.0** ([#274](https://github.com/timescale/terraform-provider-timescale/pull/274)).
+If you hit this error, upgrade to any provider version ≥ 2.4.0.
+
 ## Billing
 Services are currently billed for hourly usage. If a service is running for less than an hour,
 it will still be charged for the full hour of usage.


### PR DESCRIPTION
## What

Adds a `Troubleshooting` section to the provider index docs covering the error:

```
missing project permission: PROJECT_PERMISSION_READ for project ...
```

## Why

A customer hit this consistently on provider **v2.3.0** and it disappeared after upgrading. Investigation traced it to the `getVpc` lookup, which was the **only** query in the provider that did not pass `projectId` in versions **< 2.4.0**. Without a project scope, the server's permission check could run against a project the credentials can't read, producing `PROJECT_PERMISSION_READ`. It was fixed in **v2.4.0** by #274 (added `projectId` to `getVpc`).

This is a general provider behavior (not customer-specific), but it only surfaces for credentials whose default project differs from the project the VPC belongs to — which is why it wasn't universally reported. The note points users at the fix so they self-resolve by upgrading.

## Affected reads (pre-2.4.0)

- `timescale_vpcs`
- `timescale_peering_connection`

## Notes

- Edited `templates/index.md` and regenerated `docs/index.md` via `make generate` (docs are generated; not hand-edited).